### PR TITLE
Fix Compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.promcteam</groupId>
-            <artifactId>proskillapiparties</artifactId>
-            <version>4edd1b5e56</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>LibsDisguises</groupId>
             <artifactId>LibsDisguises</artifactId>
             <version>10.0.21</version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,6 @@
             <id>md_5-public</id>
             <url>https://repo.md-5.net/content/groups/public/</url>
         </repository>
-        <repository>
-            <id>promcteam</id>
-            <url>https://maven.pkg.github.com/promcteam/promccore</url>
-        </repository>
     </repositories>
 
     <dependencies>
@@ -158,9 +154,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>mc.promcteam</groupId>
+            <groupId>com.github.promcteam</groupId>
             <artifactId>promccore</artifactId>
-            <version>1.0.3.9</version>
+            <version>-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/sucy/skill/data/Settings.java
+++ b/src/main/java/com/sucy/skill/data/Settings.java
@@ -28,8 +28,10 @@ package com.sucy.skill.data;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+/*
 import com.sucy.party.Parties;
 import com.sucy.party.Party;
+*/
 import com.sucy.skill.SkillAPI;
 import com.sucy.skill.api.CombatProtection;
 import com.sucy.skill.api.DefaultCombatProtection;
@@ -738,10 +740,10 @@ public class Settings {
                 if (playerAlly || playerWorlds.contains(attacker.getWorld().getName())) {return false;}
 
                 if (PluginChecker.isPartiesActive() && partiesAlly) {
-                    final Parties parties = Parties.getPlugin(Parties.class);
-                    final Party   p1      = parties.getJoinedParty(player);
-                    final Party   p2      = parties.getJoinedParty((Player) target);
-                    return p1 == null || p1 != p2;
+//                    final Parties parties = Parties.getPlugin(Parties.class);
+//                    final Party   p1      = parties.getJoinedParty(player);
+//                    final Party   p2      = parties.getJoinedParty((Player) target);
+//                    return p1 == null || p1 != p2;
                 }
                 return combatProtection.canAttack(player, (Player) target);
             }


### PR DESCRIPTION
This is required to get an initial JitPack artifact of this plugin. 

Unfortunately, there is a circular dependency with Parties 🔁. This is my approach to solve it:

The Parties integration has been disabled in a seperate commit as there is no Parties artifact that JitPack can use yet.
As soon as this PR is merged, JitPack is able to build artifacts of ProSkillAPI. These can then be added to the Parties pom to get an initial artifact of Parties on JitPack.
This allows us to add parties as a JitPack dependency for this project and uncomment the disabled lines.

Required for https://github.com/BetonQuest/BetonQuest/pull/1891