### PR TITLE
Add command "loaded"

### DIFF
--- a/src/main/java/com/sucy/skill/cmd/CmdLoaded.java
+++ b/src/main/java/com/sucy/skill/cmd/CmdLoaded.java
@@ -1,0 +1,55 @@
+package com.sucy.skill.cmd;
+
+import com.sucy.skill.SkillAPI;
+import mc.promcteam.engine.mccore.commands.ConfigurableCommand;
+import mc.promcteam.engine.mccore.commands.IFunction;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A command that displays the list of loaded groups, classes, skills and attributes
+ */
+public class CmdLoaded implements IFunction {
+
+    public static final String GROUP_HEAD = "group-head";
+    public static final String CLASS_HEAD = "class-head";
+    public static final String SKILL_HEAD = "skill-head";
+    public static final String ATTR_HEAD = "attr-head";
+    private static final String END        = "end";
+    public static final String NO_ARGUMENT = "no-argument";
+    public static final String INVALID_ARGUMENT = "invalid-argument";
+
+    /**
+     * Runs the command
+     *
+     * @param cmd    command that was executed
+     * @param plugin plugin reference
+     * @param sender sender of the command
+     * @param args   argument list
+     */
+    @Override
+    public void execute(ConfigurableCommand cmd, Plugin plugin, CommandSender sender, String[] args) {
+        if (args.length<1) {
+            cmd.sendMessage(sender, NO_ARGUMENT, "&4Missing argument! <group|class|skill|attr>");
+            return;
+        }
+        switch (args[0]) {
+            case "group": sendList(cmd, sender, GROUP_HEAD,"-------Loaded group(s)-------", SkillAPI.getGroups()); break;
+            case "class": sendList(cmd, sender, CLASS_HEAD,"-------Loaded class(es)-------", SkillAPI.getClasses().keySet()); break;
+            case "skill": sendList(cmd, sender, SKILL_HEAD,"-------Loaded skill(s)-------", SkillAPI.getSkills().keySet()); break;
+            case "attr":
+            case "attribute": sendList(cmd, sender, ATTR_HEAD,"-------Loaded attribute(s)-------", SkillAPI.getAttributeManager().getKeys()); break;
+            default:
+                cmd.sendMessage(sender, INVALID_ARGUMENT, "&4Invalid argument! <group|class|skill|attr>");
+        }
+    }
+    private static void sendList(ConfigurableCommand cmd, CommandSender sender,String key, String head, Collection<?> list){
+        AtomicInteger count = new AtomicInteger(1);
+        cmd.sendMessage(sender, key, head);
+        list.forEach(entry -> sender.sendMessage(String.format("%d: %s", count.getAndIncrement(), entry)));
+        cmd.sendMessage(sender, END, "-------------------------------");
+    }
+}

--- a/src/main/java/com/sucy/skill/cmd/CmdLoaded.java
+++ b/src/main/java/com/sucy/skill/cmd/CmdLoaded.java
@@ -3,6 +3,8 @@ package com.sucy.skill.cmd;
 import com.sucy.skill.SkillAPI;
 import mc.promcteam.engine.mccore.commands.ConfigurableCommand;
 import mc.promcteam.engine.mccore.commands.IFunction;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
 
@@ -37,11 +39,11 @@ public class CmdLoaded implements IFunction {
             return;
         }
         switch (args[0]) {
-            case "group": sendList(cmd, sender, GROUP_HEAD,"-------Loaded group(s)-------", SkillAPI.getGroups()); break;
-            case "class": sendList(cmd, sender, CLASS_HEAD,"-------Loaded class(es)-------", SkillAPI.getClasses().keySet()); break;
-            case "skill": sendList(cmd, sender, SKILL_HEAD,"-------Loaded skill(s)-------", SkillAPI.getSkills().keySet()); break;
+            case "group": sendList(cmd, sender, GROUP_HEAD,"&8------- &2Loaded group(s)&8 -------", SkillAPI.getGroups()); break;
+            case "class": sendList(cmd, sender, CLASS_HEAD,"&8------- &2Loaded class(es)&8 -------", SkillAPI.getClasses().keySet()); break;
+            case "skill": sendList(cmd, sender, SKILL_HEAD,"&8------- &2Loaded skill(s)&8 -------", SkillAPI.getSkills().keySet()); break;
             case "attr":
-            case "attribute": sendList(cmd, sender, ATTR_HEAD,"-------Loaded attribute(s)-------", SkillAPI.getAttributeManager().getKeys()); break;
+            case "attribute": sendList(cmd, sender, ATTR_HEAD,"&8------- &2Loaded attribute(s)&8 -------", SkillAPI.getAttributeManager().getKeys()); break;
             default:
                 cmd.sendMessage(sender, INVALID_ARGUMENT, "&4Invalid argument! <group|class|skill|attr>");
         }
@@ -49,7 +51,7 @@ public class CmdLoaded implements IFunction {
     private static void sendList(ConfigurableCommand cmd, CommandSender sender,String key, String head, Collection<?> list){
         AtomicInteger count = new AtomicInteger(1);
         cmd.sendMessage(sender, key, head);
-        list.forEach(entry -> sender.sendMessage(String.format("%d: %s", count.getAndIncrement(), entry)));
-        cmd.sendMessage(sender, END, "-------------------------------");
+        list.forEach(entry -> sender.sendMessage(ChatColor.translateAlternateColorCodes('&',String.format("&a%d&8: &6%s", count.getAndIncrement(), entry))));
+        cmd.sendMessage(sender, END, "&8-------------------------------");
     }
 }

--- a/src/main/java/com/sucy/skill/cmd/CmdLoaded.java
+++ b/src/main/java/com/sucy/skill/cmd/CmdLoaded.java
@@ -6,6 +6,7 @@ import mc.promcteam.engine.mccore.commands.IFunction;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 import java.util.Collection;
@@ -23,6 +24,7 @@ public class CmdLoaded implements IFunction {
     private static final String END        = "end";
     public static final String NO_ARGUMENT = "no-argument";
     public static final String INVALID_ARGUMENT = "invalid-argument";
+    private static final String DISABLED   = "world-disabled";
 
     /**
      * Runs the command
@@ -34,6 +36,11 @@ public class CmdLoaded implements IFunction {
      */
     @Override
     public void execute(ConfigurableCommand cmd, Plugin plugin, CommandSender sender, String[] args) {
+        // Disabled world
+        if (sender instanceof Player && !SkillAPI.getSettings().isWorldEnabled(((Player) sender).getWorld()) && args.length == 0) {
+            cmd.sendMessage(sender, DISABLED, "&4You cannot use this command in this world");
+        }
+
         if (args.length<1) {
             cmd.sendMessage(sender, NO_ARGUMENT, "&4Missing argument! <group|class|skill|attr>");
             return;

--- a/src/main/java/com/sucy/skill/data/Permissions.java
+++ b/src/main/java/com/sucy/skill/data/Permissions.java
@@ -49,4 +49,5 @@ public class Permissions {
     public static final String RESET        = ROOT + "reset";
     public static final String REFUND       = ROOT + "refund";
     public static final String MAX_ACCOUNTS = ROOT + "max_accounts";
+    public static final String LOADED       = ROOT + "loaded";
 }

--- a/src/main/java/com/sucy/skill/manager/CmdManager.java
+++ b/src/main/java/com/sucy/skill/manager/CmdManager.java
@@ -88,7 +88,9 @@ public class CmdManager {
                 new ConfigurableCommand(api, "skill", SenderType.PLAYER_ONLY, new CmdSkill(), "Shows player skills", "", Permissions.BASIC),
                 new ConfigurableCommand(api, "unbind", SenderType.PLAYER_ONLY, new CmdUnbind(), "Unbinds held item", "", Permissions.BASIC),
                 new ConfigurableCommand(api, "world", SenderType.PLAYER_ONLY, new CmdWorld(), "Moves to world", "<world>", Permissions.WORLD),
-                new ConfigurableCommand(api, "help", SenderType.ANYONE, new CmdHelp(), "Get help for the plugin", "<page>", Permissions.BASIC)
+                new ConfigurableCommand(api, "help", SenderType.ANYONE, new CmdHelp(), "Get help for the plugin", "<page>", Permissions.BASIC),
+                new ConfigurableCommand(api, "loaded", SenderType.ANYONE, new CmdLoaded(), "Get list of loaded groups, classes, skills and attributes", "<group|class|skill|attr>", Permissions.LOADED)
+
         );
         root.addSubCommands(
                 new ConfigurableCommand(api, "forceaccount", SenderType.CONSOLE_ONLY, new CmdForceAccount(), "Changes player's account", "<player> <accountId>", Permissions.FORCE),

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -58,6 +58,9 @@ permissions:
   skillapi.gui:
     description: access to GUI editor menu
     default: op
+  skillapi.loaded:
+    description: access to loaded content
+    default: op
 
   skillapi.*:
     description: access to all commands and features


### PR DESCRIPTION
Resolve #494 and #487
Description: Displays a list of groups, classes, skills, or attributes that have been loaded
Usage: /class loaded <group|class|skill|attr>
Permission: skillapi.loaded (default with OP)