### PR TITLE
Add Shield trigger

### DIFF
--- a/src/main/java/com/sucy/skill/SkillAPI.java
+++ b/src/main/java/com/sucy/skill/SkillAPI.java
@@ -670,6 +670,7 @@ public class SkillAPI extends JavaPlugin {
         listen(new MainListener(), true);
         listen(new MechanicListener(), true);
         listen(new ProjectileListener(),true);
+        listen(new ShieldBlockListener(),true);
         listen(new StatusListener(), true);
         listen(new ToolListener(), true);
         listen(new KillListener(), true);

--- a/src/main/java/com/sucy/skill/SkillAPI.java
+++ b/src/main/java/com/sucy/skill/SkillAPI.java
@@ -129,7 +129,8 @@ public class SkillAPI extends JavaPlugin {
      */
     public static SkillAPI inst() {
         if (singleton == null) {
-            throw new SkillAPINotEnabledException("Cannot use SkillAPI methods before it is enabled - add it to your plugin.yml as a dependency");
+            throw new SkillAPINotEnabledException(
+                    "Cannot use SkillAPI methods before it is enabled - add it to your plugin.yml as a dependency");
         }
         return singleton;
     }
@@ -374,7 +375,9 @@ public class SkillAPI extends JavaPlugin {
      * @return true if data has loaded, false otherwise
      */
     public static boolean hasPlayerData(OfflinePlayer player) {
-        return singleton != null && player != null && singleton.players.containsKey(player.getUniqueId().toString().toLowerCase());
+        return singleton != null && player != null && singleton.players.containsKey(player.getUniqueId()
+                .toString()
+                .toLowerCase());
     }
 
     /**
@@ -388,7 +391,8 @@ public class SkillAPI extends JavaPlugin {
     }
 
     public static void unloadPlayerData(final OfflinePlayer player, final boolean skipSaving) {
-        if (singleton == null || player == null || singleton.disabling || !singleton.players.containsKey(player.getUniqueId().toString().toLowerCase())) {
+        if (singleton == null || player == null || singleton.disabling
+                || !singleton.players.containsKey(player.getUniqueId().toString().toLowerCase())) {
             return;
         }
 
@@ -619,7 +623,7 @@ public class SkillAPI extends JavaPlugin {
             throw new IllegalStateException("Cannot enable SkillAPI twice!");
         }
 
-        String  coreVersion       = NexEngine.getEngine().getDescription().getVersion();
+        String coreVersion = NexEngine.getEngine().getDescription().getVersion();
         if (!DependencyRequirement.meetsVersion(DependencyRequirement.MIN_CORE_VERSION, coreVersion)) {
             getLogger().warning("Missing required ProMCCore version. " + coreVersion + " installed. "
                     + DependencyRequirement.MIN_CORE_VERSION + " required. Disabling.");
@@ -669,8 +673,8 @@ public class SkillAPI extends JavaPlugin {
         listen(new BuffListener(), true);
         listen(new MainListener(), true);
         listen(new MechanicListener(), true);
-        listen(new ProjectileListener(),true);
-        listen(new ShieldBlockListener(),true);
+        listen(new ProjectileListener(), true);
+        listen(new ShieldBlockListener(), true);
         listen(new StatusListener(), true);
         listen(new ToolListener(), true);
         listen(new KillListener(), true);
@@ -739,7 +743,7 @@ public class SkillAPI extends JavaPlugin {
     public void listen(SkillAPIListener listener, boolean enabled) {
         if (enabled) {
             // Prevent double listener registering
-            for (Iterator<SkillAPIListener> iterator = this.listeners.iterator(); iterator.hasNext();) {
+            for (Iterator<SkillAPIListener> iterator = this.listeners.iterator(); iterator.hasNext(); ) {
                 SkillAPIListener listener1 = iterator.next();
                 if (listener.getClass().equals(listener1.getClass())) {
                     HandlerList.unregisterAll(listener1);

--- a/src/main/java/com/sucy/skill/api/event/PlayerBlockDamageEvent.java
+++ b/src/main/java/com/sucy/skill/api/event/PlayerBlockDamageEvent.java
@@ -20,7 +20,7 @@ public class PlayerBlockDamageEvent extends PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
     @Getter private Entity source;
     @Getter private double damage;
-    @Getter private boolean isProjectile = false;
+    @Getter private String type = "melee";
 
 
     public PlayerBlockDamageEvent(
@@ -30,7 +30,7 @@ public class PlayerBlockDamageEvent extends PlayerEvent {
         super(statEvent.getPlayer());
         source = damageEvent.getDamager();
         if (source instanceof Projectile){
-            isProjectile = true;
+            type = "projectile";
             ProjectileSource ps = ((Projectile) source).getShooter();
             if (ps instanceof BlockProjectileSource) {
                 Location locTarget = ((BlockProjectileSource) ps).getBlock().getLocation();

--- a/src/main/java/com/sucy/skill/api/event/PlayerBlockDamageEvent.java
+++ b/src/main/java/com/sucy/skill/api/event/PlayerBlockDamageEvent.java
@@ -24,11 +24,11 @@ public class PlayerBlockDamageEvent extends PlayerEvent {
 
 
     public PlayerBlockDamageEvent(
-            EntityDamageByEntityEvent damageEvent,
+            Entity damager,
             PlayerStatisticIncrementEvent statEvent)
     {
         super(statEvent.getPlayer());
-        source = damageEvent.getDamager();
+        source = damager;
         if (source instanceof Projectile){
             type = "projectile";
             ProjectileSource ps = ((Projectile) source).getShooter();

--- a/src/main/java/com/sucy/skill/api/event/PlayerBlockDamageEvent.java
+++ b/src/main/java/com/sucy/skill/api/event/PlayerBlockDamageEvent.java
@@ -6,7 +6,6 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.HandlerList;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.event.player.PlayerStatisticIncrementEvent;
 import org.bukkit.projectiles.BlockProjectileSource;
@@ -18,27 +17,28 @@ import org.jetbrains.annotations.NotNull;
  */
 public class PlayerBlockDamageEvent extends PlayerEvent {
     private static final HandlerList handlers = new HandlerList();
-    @Getter private Entity source;
-    @Getter private double damage;
-    @Getter private String type = "melee";
+    @Getter
+    private              Entity      source;
+    @Getter
+    private              double      damage;
+    @Getter
+    private              String      type     = "melee";
 
 
     public PlayerBlockDamageEvent(
             Entity damager,
-            PlayerStatisticIncrementEvent statEvent)
-    {
+            PlayerStatisticIncrementEvent statEvent) {
         super(statEvent.getPlayer());
         source = damager;
-        if (source instanceof Projectile){
+        if (source instanceof Projectile) {
             type = "projectile";
             ProjectileSource ps = ((Projectile) source).getShooter();
             if (ps instanceof BlockProjectileSource) {
                 Location locTarget = ((BlockProjectileSource) ps).getBlock().getLocation();
                 source = new TempEntity(locTarget);
-            }
-            else source = (Entity) ps;
+            } else source = (Entity) ps;
         }
-        damage = (statEvent.getNewValue()-statEvent.getPreviousValue())/10D;
+        damage = (statEvent.getNewValue() - statEvent.getPreviousValue()) / 10D;
     }
 
     /**

--- a/src/main/java/com/sucy/skill/api/event/PlayerBlockDamageEvent.java
+++ b/src/main/java/com/sucy/skill/api/event/PlayerBlockDamageEvent.java
@@ -1,0 +1,61 @@
+package com.sucy.skill.api.event;
+
+import com.sucy.skill.dynamic.TempEntity;
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.player.PlayerStatisticIncrementEvent;
+import org.bukkit.projectiles.BlockProjectileSource;
+import org.bukkit.projectiles.ProjectileSource;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Event call when player block damage with a shield
+ */
+public class PlayerBlockDamageEvent extends PlayerEvent {
+    private static final HandlerList handlers = new HandlerList();
+    @Getter private Entity source;
+    @Getter private double damage;
+    @Getter private boolean isProjectile = false;
+
+
+    public PlayerBlockDamageEvent(
+            EntityDamageByEntityEvent damageEvent,
+            PlayerStatisticIncrementEvent statEvent)
+    {
+        super(statEvent.getPlayer());
+        source = damageEvent.getDamager();
+        if (source instanceof Projectile){
+            isProjectile = true;
+            ProjectileSource ps = ((Projectile) source).getShooter();
+            if (ps instanceof BlockProjectileSource) {
+                Location locTarget = ((BlockProjectileSource) ps).getBlock().getLocation();
+                source = new TempEntity(locTarget);
+            }
+            else source = (Entity) ps;
+        }
+        damage = (statEvent.getNewValue()-statEvent.getPreviousValue())/10D;
+    }
+
+    /**
+     * Retrieves the handlers for the event
+     *
+     * @return list of event handlers
+     */
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {return handlers;}
+
+    /**
+     * Retrieves the handlers for the event
+     *
+     * @return list of event handlers
+     */
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/com/sucy/skill/dynamic/ComponentRegistry.java
+++ b/src/main/java/com/sucy/skill/dynamic/ComponentRegistry.java
@@ -61,6 +61,7 @@ public class ComponentRegistry {
         register(new ProjectileTickTrigger());
         register(new SkillDealtTrigger());
         register(new SkillTakenTrigger());
+        register(new ShieldTrigger());
         register(new SkillCastTrigger());
         register(new ConsumeTrigger());
 

--- a/src/main/java/com/sucy/skill/dynamic/trigger/ShieldTrigger.java
+++ b/src/main/java/com/sucy/skill/dynamic/trigger/ShieldTrigger.java
@@ -29,9 +29,9 @@ public class ShieldTrigger implements Trigger<PlayerBlockDamageEvent> {
     public boolean shouldTrigger(PlayerBlockDamageEvent event, int level, Settings settings) {
         String type = settings.getString("type", "Both").toLowerCase();
         if (!type.equals("both") && !type.equals(event.getType())) return false;
-        double min  = settings.getDouble("dmg-min", 0);
-        double max  = settings.getDouble("dmg-max", 9999);
-        return event.getDamage()>=min && event.getDamage()<=max;
+        double min = settings.getDouble("dmg-min", 0);
+        double max = settings.getDouble("dmg-max", 9999);
+        return event.getDamage() >= min && event.getDamage() <= max;
     }
 
     /**
@@ -55,6 +55,6 @@ public class ShieldTrigger implements Trigger<PlayerBlockDamageEvent> {
      */
     @Override
     public LivingEntity getTarget(PlayerBlockDamageEvent event, Settings settings) {
-        return settings.getBool("target",false)? event.getPlayer():(LivingEntity) event.getSource() ;
+        return settings.getBool("target", false) ? event.getPlayer() : (LivingEntity) event.getSource();
     }
 }

--- a/src/main/java/com/sucy/skill/dynamic/trigger/ShieldTrigger.java
+++ b/src/main/java/com/sucy/skill/dynamic/trigger/ShieldTrigger.java
@@ -55,6 +55,6 @@ public class ShieldTrigger implements Trigger<PlayerBlockDamageEvent> {
      */
     @Override
     public LivingEntity getTarget(PlayerBlockDamageEvent event, Settings settings) {
-        return settings.getBool("target",false)? (LivingEntity) event.getSource() :event.getPlayer();
+        return settings.getBool("target",false)? event.getPlayer():(LivingEntity) event.getSource() ;
     }
 }

--- a/src/main/java/com/sucy/skill/dynamic/trigger/ShieldTrigger.java
+++ b/src/main/java/com/sucy/skill/dynamic/trigger/ShieldTrigger.java
@@ -1,0 +1,60 @@
+package com.sucy.skill.dynamic.trigger;
+
+import com.sucy.skill.api.Settings;
+import com.sucy.skill.api.event.PlayerBlockDamageEvent;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.Map;
+
+public class ShieldTrigger implements Trigger<PlayerBlockDamageEvent> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getKey() {return "SHIELD";}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<PlayerBlockDamageEvent> getEvent() {
+        return PlayerBlockDamageEvent.class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean shouldTrigger(PlayerBlockDamageEvent event, int level, Settings settings) {
+        String type = settings.getString("type", "Both").toLowerCase();
+        if (!type.equals("both") && !type.equals(event.getType())) return false;
+        double min  = settings.getDouble("dmg-min", 0);
+        double max  = settings.getDouble("dmg-max", 9999);
+        return event.getDamage()>=min && event.getDamage()<=max;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setValues(PlayerBlockDamageEvent event, Map<String, Object> data) {
+        data.put("api-blocked", event.getDamage());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LivingEntity getCaster(PlayerBlockDamageEvent event) {
+        return event.getPlayer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public LivingEntity getTarget(PlayerBlockDamageEvent event, Settings settings) {
+        return settings.getBool("target",false)? (LivingEntity) event.getSource() :event.getPlayer();
+    }
+}

--- a/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
+++ b/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
@@ -28,7 +28,6 @@ public class ShieldBlockListener extends SkillAPIListener {
         Player player = (Player) event.getEntity();
         if (!player.isBlocking()) return;
         volatileMap.put(player, event);
-        new Timer().schedule(new TimerTask() {@Override public void run() {volatileMap.remove(player);}},100);
     }
 
     /**

--- a/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
+++ b/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
@@ -1,0 +1,43 @@
+package com.sucy.skill.listener;
+
+import com.sucy.skill.api.event.PlayerBlockDamageEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.Statistic;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.player.PlayerStatisticIncrementEvent;
+
+import java.util.HashMap;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Listener to throw custom {@link PlayerBlockDamageEvent}
+ */
+public class ShieldBlockListener extends SkillAPIListener {
+
+    private final HashMap<Player, EntityDamageByEntityEvent> volatileMap = new HashMap<>();
+
+    /**
+     * Remember EntityDamageByEntityEvent in a moment
+     */
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event){
+        if (!(event.getEntity() instanceof Player)) return;
+        Player player = (Player) event.getEntity();
+        volatileMap.put(player, event);
+        new Timer().schedule(new TimerTask() {@Override public void run() {volatileMap.remove(player);}},100);
+    }
+
+    /**
+     * Trigger for {@link PlayerBlockDamageEvent}
+     */
+    @EventHandler
+    public void onStat(PlayerStatisticIncrementEvent event){
+        if (!event.getStatistic().equals(Statistic.DAMAGE_BLOCKED_BY_SHIELD)) return;
+        Player player = event.getPlayer();
+        if (!volatileMap.containsKey(player)) return;
+        Bukkit.getPluginManager().callEvent(new PlayerBlockDamageEvent(volatileMap.get(player), event));
+    }
+}

--- a/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
+++ b/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
@@ -26,6 +26,7 @@ public class ShieldBlockListener extends SkillAPIListener {
     public void onDamage(EntityDamageByEntityEvent event){
         if (!(event.getEntity() instanceof Player)) return;
         Player player = (Player) event.getEntity();
+        if (!player.isBlocking()) return;
         volatileMap.put(player, event);
         new Timer().schedule(new TimerTask() {@Override public void run() {volatileMap.remove(player);}},100);
     }

--- a/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
+++ b/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
@@ -3,6 +3,7 @@ package com.sucy.skill.listener;
 import com.sucy.skill.api.event.PlayerBlockDamageEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Statistic;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -11,13 +12,14 @@ import org.bukkit.event.player.PlayerStatisticIncrementEvent;
 import java.util.HashMap;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.UUID;
 
 /**
  * Listener to throw custom {@link PlayerBlockDamageEvent}
  */
 public class ShieldBlockListener extends SkillAPIListener {
 
-    private final HashMap<Player, EntityDamageByEntityEvent> volatileMap = new HashMap<>();
+    private final HashMap<UUID, Entity> volatileMap = new HashMap<>();
 
     /**
      * Remember EntityDamageByEntityEvent in a moment
@@ -27,7 +29,9 @@ public class ShieldBlockListener extends SkillAPIListener {
         if (!(event.getEntity() instanceof Player)) return;
         Player player = (Player) event.getEntity();
         if (!player.isBlocking()) return;
-        volatileMap.put(player, event);
+        UUID player_uuid = player.getUniqueId();
+        volatileMap.put(player_uuid, event.getDamager());
+        new Timer().schedule(new TimerTask() {@Override public void run() {volatileMap.remove(player_uuid);}},100);
     }
 
     /**
@@ -37,7 +41,7 @@ public class ShieldBlockListener extends SkillAPIListener {
     public void onStat(PlayerStatisticIncrementEvent event){
         if (!event.getStatistic().equals(Statistic.DAMAGE_BLOCKED_BY_SHIELD)) return;
         Player player = event.getPlayer();
-        if (!volatileMap.containsKey(player)) return;
-        Bukkit.getPluginManager().callEvent(new PlayerBlockDamageEvent(volatileMap.get(player), event));
+        if (!volatileMap.containsKey(player.getUniqueId())) return;
+        Bukkit.getPluginManager().callEvent(new PlayerBlockDamageEvent(volatileMap.get(player.getUniqueId()), event));
     }
 }

--- a/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
+++ b/src/main/java/com/sucy/skill/listener/ShieldBlockListener.java
@@ -25,20 +25,25 @@ public class ShieldBlockListener extends SkillAPIListener {
      * Remember EntityDamageByEntityEvent in a moment
      */
     @EventHandler
-    public void onDamage(EntityDamageByEntityEvent event){
+    public void onDamage(EntityDamageByEntityEvent event) {
         if (!(event.getEntity() instanceof Player)) return;
         Player player = (Player) event.getEntity();
         if (!player.isBlocking()) return;
         UUID player_uuid = player.getUniqueId();
         volatileMap.put(player_uuid, event.getDamager());
-        new Timer().schedule(new TimerTask() {@Override public void run() {volatileMap.remove(player_uuid);}},100);
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                volatileMap.remove(player_uuid);
+            }
+        }, 100);
     }
 
     /**
      * Trigger for {@link PlayerBlockDamageEvent}
      */
     @EventHandler
-    public void onStat(PlayerStatisticIncrementEvent event){
+    public void onStat(PlayerStatisticIncrementEvent event) {
         if (!event.getStatistic().equals(Statistic.DAMAGE_BLOCKED_BY_SHIELD)) return;
         Player player = event.getPlayer();
         if (!volatileMap.containsKey(player.getUniqueId())) return;


### PR DESCRIPTION
ShieldTrigger: Applies skill effects when a player block damage with a shield. Use {api-blocked} to get how many damage was blocked
- Mana: true/false
- Cooldown: true/false
- Target Caster: true/false
- Type: Both/Melee/Projectile
- Min Damage: double
- Max Damage: double

Skills that have been used to test: [ShieldTest.zip](https://github.com/promcteam/proskillapi/files/12257755/ShieldTest.zip)
