### PR TITLE
Add signal trigger and mechanic

### DIFF
--- a/src/main/java/com/sucy/skill/api/event/SignalEmitEvent.java
+++ b/src/main/java/com/sucy/skill/api/event/SignalEmitEvent.java
@@ -16,7 +16,7 @@ public class SignalEmitEvent extends Event {
     private final LivingEntity emitter;
     private final LivingEntity receiver;
     private final String signal;
-    private final List<String> arguments;
+    private final List<Object> arguments;
     private final boolean selfHandling;
 
     /**
@@ -28,7 +28,7 @@ public class SignalEmitEvent extends Event {
      * @param arguments     arguments use for handling signal
      * @param selfHandling  whether the signal is handling by the emitter or by the receiver
      */
-    public SignalEmitEvent(Skill skill, LivingEntity emitter, LivingEntity receiver, String signal, List<String> arguments, boolean selfHandling) {
+    public SignalEmitEvent(Skill skill, LivingEntity emitter, LivingEntity receiver, String signal, List<Object> arguments, boolean selfHandling) {
         this.skill = skill;
         this.emitter = emitter;
         this.receiver = receiver;

--- a/src/main/java/com/sucy/skill/api/event/SignalEmitEvent.java
+++ b/src/main/java/com/sucy/skill/api/event/SignalEmitEvent.java
@@ -1,0 +1,58 @@
+package com.sucy.skill.api.event;
+
+import com.sucy.skill.api.skills.Skill;
+import lombok.Getter;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.List;
+
+@Getter
+public class SignalEmitEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final Skill skill;
+    private final LivingEntity emitter;
+    private final LivingEntity receiver;
+    private final String signal;
+    private final List<String> arguments;
+    private final boolean selfHandling;
+
+    /**
+     * Event to call custom signal
+     * @param skill         skill used to emit signal
+     * @param emitter        entity that emitted signal
+     * @param receiver      entity that will receive signal
+     * @param signal        signal name and encrypted arguments
+     * @param arguments     arguments use for handling signal
+     * @param selfHandling  whether the signal is handling by the emitter or by the receiver
+     */
+    public SignalEmitEvent(Skill skill, LivingEntity emitter, LivingEntity receiver, String signal, List<String> arguments, boolean selfHandling) {
+        this.skill = skill;
+        this.emitter = emitter;
+        this.receiver = receiver;
+        this.signal = signal;
+        this.arguments = arguments;
+        this.selfHandling = selfHandling;
+    }
+
+    /**
+     * Retrieves the handlers for the event
+     *
+     * @return list of event handlers
+     */
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * Retrieves the handlers for the event
+     *
+     * @return list of event handlers
+     */
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/com/sucy/skill/dynamic/ComponentRegistry.java
+++ b/src/main/java/com/sucy/skill/dynamic/ComponentRegistry.java
@@ -63,6 +63,7 @@ public class ComponentRegistry {
         register(new SkillDealtTrigger());
         register(new SkillTakenTrigger());
         register(new ShieldTrigger());
+        register(new SignalTrigger());
         register(new SkillCastTrigger());
         register(new ConsumeTrigger());
 
@@ -180,6 +181,7 @@ public class ComponentRegistry {
         register(new PushMechanic());
         register(new RememberTargetsMechanic());
         register(new RepeatMechanic());
+        register(new SignalEmitMechanic());
         register(new SkillCastMechanic());
         register(new StatMechanic());
         register(new SoundMechanic());

--- a/src/main/java/com/sucy/skill/dynamic/mechanic/SignalEmitMechanic.java
+++ b/src/main/java/com/sucy/skill/dynamic/mechanic/SignalEmitMechanic.java
@@ -4,7 +4,9 @@ import com.sucy.skill.api.event.SignalEmitEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class SignalEmitMechanic extends MechanicComponent{
     private static final String SIGNAL = "signal";
@@ -30,7 +32,10 @@ public class SignalEmitMechanic extends MechanicComponent{
         String signal = settings.getString(SIGNAL);
         List<String> arguments = settings.getStringList(ARGUMENT);
         boolean selfHandling = settings.getBool(HANDLER);
-        targets.forEach(target -> Bukkit.getPluginManager().callEvent(new SignalEmitEvent(skill, caster, target, signal, arguments, selfHandling)));
+        targets.forEach(target -> {
+            List<String> filtered = arguments.parallelStream().map(arg -> filter(caster, target, arg)).collect(Collectors.toList());
+            Bukkit.getPluginManager().callEvent(new SignalEmitEvent(skill, caster, target, signal, filtered, selfHandling));
+        });
         return true;
     }
 }

--- a/src/main/java/com/sucy/skill/dynamic/mechanic/SignalEmitMechanic.java
+++ b/src/main/java/com/sucy/skill/dynamic/mechanic/SignalEmitMechanic.java
@@ -1,0 +1,36 @@
+package com.sucy.skill.dynamic.mechanic;
+
+import com.sucy.skill.api.event.SignalEmitEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.List;
+
+public class SignalEmitMechanic extends MechanicComponent{
+    private static final String SIGNAL = "signal";
+    private static final String ARGUMENT = "argument";
+    private static final String HANDLER = "handler";
+
+    @Override
+    public String getKey() {
+        return "signal emit";
+    }
+
+    /**
+     * Executes the component
+     *
+     * @param caster  caster of the skill
+     * @param level   level of the skill
+     * @param targets targets to apply to
+     * @param force
+     * @return true if applied to something, false otherwise
+     */
+    @Override
+    public boolean execute(LivingEntity caster, int level, List<LivingEntity> targets, boolean force) {
+        String signal = settings.getString(SIGNAL);
+        List<String> arguments = settings.getStringList(ARGUMENT);
+        boolean selfHandling = settings.getBool(HANDLER);
+        targets.forEach(target -> Bukkit.getPluginManager().callEvent(new SignalEmitEvent(skill, caster, target, signal, arguments, selfHandling)));
+        return true;
+    }
+}

--- a/src/main/java/com/sucy/skill/dynamic/mechanic/SignalEmitMechanic.java
+++ b/src/main/java/com/sucy/skill/dynamic/mechanic/SignalEmitMechanic.java
@@ -1,6 +1,7 @@
 package com.sucy.skill.dynamic.mechanic;
 
 import com.sucy.skill.api.event.SignalEmitEvent;
+import com.sucy.skill.dynamic.DynamicSkill;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
 
@@ -33,7 +34,10 @@ public class SignalEmitMechanic extends MechanicComponent{
         List<String> arguments = settings.getStringList(ARGUMENT);
         boolean selfHandling = settings.getBool(HANDLER);
         targets.forEach(target -> {
-            List<String> filtered = arguments.parallelStream().map(arg -> filter(caster, target, arg)).collect(Collectors.toList());
+            List<Object> filtered = arguments.parallelStream().map(arg -> {
+                Object value = DynamicSkill.getCastData(caster).get(arg);
+                return value==null?filter(caster, target, arg):value;
+            }).collect(Collectors.toList());
             Bukkit.getPluginManager().callEvent(new SignalEmitEvent(skill, caster, target, signal, filtered, selfHandling));
         });
         return true;

--- a/src/main/java/com/sucy/skill/dynamic/trigger/SignalTrigger.java
+++ b/src/main/java/com/sucy/skill/dynamic/trigger/SignalTrigger.java
@@ -39,9 +39,9 @@ public class SignalTrigger implements Trigger<SignalEmitEvent>{
      */
     @Override
     public void setValues(SignalEmitEvent event, Map<String, Object> data) {
-        List<String> arguments = event.getArguments();
+        List<Object> arguments = event.getArguments();
         for (int i = 0; i < arguments.size(); i++) {
-            String arg = arguments.get(i);
+            Object arg = arguments.get(i);
             if (i==0) data.put("api-arg", arg);
             data.put(String.format("api-arg[%d]", i), arg);
         }

--- a/src/main/java/com/sucy/skill/dynamic/trigger/SignalTrigger.java
+++ b/src/main/java/com/sucy/skill/dynamic/trigger/SignalTrigger.java
@@ -9,21 +9,34 @@ import java.util.Map;
 import java.util.Objects;
 
 public class SignalTrigger implements Trigger<SignalEmitEvent>{
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getKey() {
         return "signal";
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Class<SignalEmitEvent> getEvent() {
         return SignalEmitEvent.class;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean shouldTrigger(SignalEmitEvent event, int level, Settings settings) {
         return Objects.equals(settings.getString("signal"), event.getSignal());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setValues(SignalEmitEvent event, Map<String, Object> data) {
         List<String> arguments = event.getArguments();
@@ -34,11 +47,17 @@ public class SignalTrigger implements Trigger<SignalEmitEvent>{
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public LivingEntity getCaster(SignalEmitEvent event) {
         return event.isSelfHandling() ? event.getEmitter() : event.getReceiver();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public LivingEntity getTarget(SignalEmitEvent event, Settings settings) {
         return settings.getBool("target", false) ? event.getReceiver() : event.getEmitter();

--- a/src/main/java/com/sucy/skill/dynamic/trigger/SignalTrigger.java
+++ b/src/main/java/com/sucy/skill/dynamic/trigger/SignalTrigger.java
@@ -1,0 +1,46 @@
+package com.sucy.skill.dynamic.trigger;
+
+import com.sucy.skill.api.Settings;
+import com.sucy.skill.api.event.SignalEmitEvent;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class SignalTrigger implements Trigger<SignalEmitEvent>{
+    @Override
+    public String getKey() {
+        return "signal";
+    }
+
+    @Override
+    public Class<SignalEmitEvent> getEvent() {
+        return SignalEmitEvent.class;
+    }
+
+    @Override
+    public boolean shouldTrigger(SignalEmitEvent event, int level, Settings settings) {
+        return Objects.equals(settings.getString("signal"), event.getSignal());
+    }
+
+    @Override
+    public void setValues(SignalEmitEvent event, Map<String, Object> data) {
+        List<String> arguments = event.getArguments();
+        for (int i = 0; i < arguments.size(); i++) {
+            String arg = arguments.get(i);
+            if (i==0) data.put("api-arg", arg);
+            data.put(String.format("api-arg[%d]", i), arg);
+        }
+    }
+
+    @Override
+    public LivingEntity getCaster(SignalEmitEvent event) {
+        return event.isSelfHandling() ? event.getEmitter() : event.getReceiver();
+    }
+
+    @Override
+    public LivingEntity getTarget(SignalEmitEvent event, Settings settings) {
+        return settings.getBool("target", false) ? event.getReceiver() : event.getEmitter();
+    }
+}


### PR DESCRIPTION
resolve #520 #537 
New mechanic: Signal Emit
Description: emit a custom signal to be reusable is separate processing
Signal: Name of signal will be emit
Self-handling: If true, The signal will be handling by the sender himself with the target being the current target
Arguments: Arguments used for signal processing. One value per line. The value will be stored in value api-arg[<index>]. The first value will be specially stored at api-arg

New trigger: Signal
Description: Applies skill effects when the player receive a signal emitted from Signal Emit mechanic.
Target Receiver: True makes children target the receiver. False makes children target the emitter