### PR TITLE
Add placeholder for dynamic data

### DIFF
--- a/src/main/java/com/sucy/skill/api/util/FlagData.java
+++ b/src/main/java/com/sucy/skill/api/util/FlagData.java
@@ -37,6 +37,7 @@ import org.bukkit.scheduler.BukkitTask;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Set;
 
 /**
  * Represents flags set on an entity
@@ -169,6 +170,15 @@ public class FlagData {
         return flags.containsKey(flag);
     }
 
+    /**
+     * Check the list of all active flags
+     *
+     * @return Set name of all active flag.
+     */
+    public Set<String> flagList(){
+        return flags.keySet();
+    }
+
     private class FlagTask extends BukkitRunnable {
         private final String flag;
 
@@ -185,4 +195,6 @@ public class FlagData {
             removeFlag(flag, FlagExpireEvent.ExpireReason.TIME);
         }
     }
+
+
 }


### PR DESCRIPTION
**Add some placeholder that useful for scoreboard display**

`%sapi_dynamic_value_<value>%`
Return current value. "0" is default.
Resolve #346 

`%sapi_dynamic_flags[_<prefix>]%`
Return list of active flag.
If a prefix is defined, returns a list of active flags beginning with prefix after the prefix has been removed.

`%sapi_dynamic_flagremain_<flag>%`
Return remaining duration of flag.

`%sapi_dynamic_cooldown_<skill>%`
Return current cooldown of skill in seconds.
Resolve #470 and #562