### PR TITLE
[Pull Request] Base and Modifier attribute costs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.promcteam</groupId>
     <artifactId>proskillapi</artifactId>
-    <version>1.1.12-R1</version>
+    <version>1.1.13-R0.1-SNAPSHOT</version>
 
     <name>ProSkillAPI</name>
     <description>A Minecraft Bukkit plugin aiming to provide an easy code API and skill editor for all server owners to

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.promcteam</groupId>
     <artifactId>proskillapi</artifactId>
-    <version>1.1.13-R0.1-SNAPSHOT</version>
+    <version>1.1.12-R1</version>
 
     <name>ProSkillAPI</name>
     <description>A Minecraft Bukkit plugin aiming to provide an easy code API and skill editor for all server owners to

--- a/src/main/java/com/sucy/skill/api/player/PlayerData.java
+++ b/src/main/java/com/sucy/skill/api/player/PlayerData.java
@@ -394,15 +394,22 @@ public class PlayerData {
         key = key.toLowerCase();
         int current = getInvestedAttribute(key);
         int max     = SkillAPI.getAttributeManager().getAttribute(key).getMax();
-        if (attribPoints > 0 && current < max) {
+        // iomatix base/mod cost
+        int cost_base = SkillAPI.getAttributeManager().getAttribute(key).getCostBase();
+        double cost_mod = SkillAPI.getAttributeManager().getAttribute(key).getCostMod();
+
+        // iomatix Logic behind: cost_base+floor(current*cost_mod) -> is new cost so...
+        int cost = SkillAPI.getAttributeManager().getAttribute(key).getCostBase() + (int) Math.floor(current*SkillAPI.getAttributeManager().getAttribute(key).getCostMod());
+        // iomatix apply the new logic below:
+        if (attribPoints >= cost && current < max) {
             attributes.put(key, current + 1);
-            attribPoints--;
+            attribPoints -= cost; // iomatix new cost has been applied
 
             PlayerUpAttributeEvent event = new PlayerUpAttributeEvent(this, key);
             Bukkit.getPluginManager().callEvent(event);
             if (event.isCancelled()) {
                 attributes.put(key, current);
-                attribPoints++;
+                attribPoints += cost; // iomatix get the cost back
             } else {
                 return true;
             }

--- a/src/main/java/com/sucy/skill/api/player/PlayerData.java
+++ b/src/main/java/com/sucy/skill/api/player/PlayerData.java
@@ -394,11 +394,8 @@ public class PlayerData {
         key = key.toLowerCase();
         int current = getInvestedAttribute(key);
         int max     = SkillAPI.getAttributeManager().getAttribute(key).getMax();
-        // iomatix base/mod cost
-        int cost_base = SkillAPI.getAttributeManager().getAttribute(key).getCostBase();
-        double cost_mod = SkillAPI.getAttributeManager().getAttribute(key).getCostMod();
 
-        // iomatix Logic behind: cost_base+floor(current*cost_mod) -> is new cost so...
+        // iomatix Logic behind: costBase+floor(current*costMod) -> is new cost so...
         int cost = SkillAPI.getAttributeManager().getAttribute(key).getCostBase() + (int) Math.floor(current*SkillAPI.getAttributeManager().getAttribute(key).getCostMod());
         // iomatix apply the new logic below:
         if (attribPoints >= cost && current < max) {

--- a/src/main/java/com/sucy/skill/cmd/CmdAP.java
+++ b/src/main/java/com/sucy/skill/cmd/CmdAP.java
@@ -84,15 +84,7 @@ public class CmdAP implements IFunction {
                 cmd.sendMessage(sender, NOT_NUMBER, ChatColor.RED + "That is not a valid skill point amount");
                 return;
             }
-
-            // Invalid amount of skill points
-            if (amount <= 0) {
-                cmd.sendMessage(sender,
-                        NOT_POSITIVE,
-                        ChatColor.RED + "You must give a positive amount of skill points");
-                return;
-            }
-
+            
             // Give skill points
             PlayerData data = SkillAPI.getPlayerData(target);
             data.giveAttribPoints(amount);

--- a/src/main/java/com/sucy/skill/manager/AttributeManager.java
+++ b/src/main/java/com/sucy/skill/manager/AttributeManager.java
@@ -204,11 +204,20 @@ public class AttributeManager {
         private static final String STATS     = "stats";
         private static final String MAX       = "max";
 
+        // iomatix: base_cost and the modifier
+        private static final String COSTBASE = "cost_base";
+        private static final String COSTMOD = "cost_modifier";
+
         // Attribute description
         private String    key;
         private String    display;
         private ItemStack icon;
         private int       max;
+
+        // iomatix: base_cost and the modifier
+
+        private int cost_base;
+        private double cost_modifier;
 
         // Dynamic global modifiers
         private Map<ComponentType, Map<String, AttributeValue[]>> dynamicModifiers = new EnumMap<>(ComponentType.class);
@@ -228,6 +237,10 @@ public class AttributeManager {
             this.display = data.getString(DISPLAY, key);
             this.icon = Data.parseIcon(data);
             this.max = data.getInt(MAX, 999);
+            // iomatix: base_cost and the modifier
+                // eg. per 0.3 increase -> 0.3=>0, 0.6=>0, 0.9=>0, 1.2=>1 (first additional cost point) etc.
+            this.cost_base = data.getInt(COSTBASE, 1);
+            this.cost_modifier = data.getDouble(COSTMOD, 0.3);
 
             // Load dynamic global settings
             DataSection globals = data.getSection(GLOBAL);
@@ -310,7 +323,8 @@ public class AttributeManager {
         private String filter(PlayerData data, String text) {
             return text
                     .replace("{amount}", "" + data.getInvestedAttribute(key))
-                    .replace("{total}", "" + data.getAttribute(key));
+                    .replace("{total}", "" + data.getAttribute(key))
+                    ;
         }
 
         /**
@@ -344,6 +358,25 @@ public class AttributeManager {
          */
         public int getMax() {
             return max;
+        }
+
+        // iomatix: base_cost and the modifier
+        /**
+         * Retrieves the starting cost of the attribute upgrade.
+         *
+         * @return cost_base amount
+         */
+        public int getCostBase(){
+            return cost_base;
+        }
+        /**
+         * Retrieves the raw additional cost of the attribute upgrade.
+         * It should be converted to int e.g. using (int) Math.floor function.
+         *
+         * @return cost_modifier
+         */
+        public double getCostMod(){
+            return cost_modifier;
         }
 
         /**

--- a/src/main/java/com/sucy/skill/manager/AttributeManager.java
+++ b/src/main/java/com/sucy/skill/manager/AttributeManager.java
@@ -204,7 +204,7 @@ public class AttributeManager {
         private static final String STATS     = "stats";
         private static final String MAX       = "max";
 
-        // iomatix: base_cost and the modifier
+        // iomatix: cost and the modifier
         private static final String COSTBASE = "cost_base";
         private static final String COSTMOD = "cost_modifier";
 
@@ -214,10 +214,10 @@ public class AttributeManager {
         private ItemStack icon;
         private int       max;
 
-        // iomatix: base_cost and the modifier
+        // iomatix: cost and the modifier
 
-        private int cost_base;
-        private double cost_modifier;
+        private int costBase;
+        private double costModifier;
 
         // Dynamic global modifiers
         private Map<ComponentType, Map<String, AttributeValue[]>> dynamicModifiers = new EnumMap<>(ComponentType.class);
@@ -238,9 +238,9 @@ public class AttributeManager {
             this.icon = Data.parseIcon(data);
             this.max = data.getInt(MAX, 999);
             // iomatix: base_cost and the modifier
-                // e.g. per 0.3 increase -> 0.3=>0, 0.6=>0, 0.9=>0, 1.2=>1 (first additional cost point) etc.
-            this.cost_base = data.getInt(COSTBASE, 1);
-            this.cost_modifier = data.getDouble(COSTMOD, 0.3);
+                // e.g. per 0.3 increase -> 0.3=>0, 0.6=>0, 0.9=>0, 1.2=>1 (the first additional cost point) etc.
+            this.costBase = data.getInt(COSTBASE, 1);
+            this.costModifier = data.getDouble(COSTMOD, 0.0);
 
             // Load dynamic global settings
             DataSection globals = data.getSection(GLOBAL);
@@ -364,19 +364,19 @@ public class AttributeManager {
         /**
          * Retrieves the starting cost of the attribute upgrade.
          *
-         * @return cost_base amount
+         * @return costBase amount
          */
         public int getCostBase(){
-            return cost_base;
+            return costBase;
         }
         /**
          * Retrieves the raw additional cost of the attribute upgrade.
          * It should be converted to int e.g. using (int) Math.floor function.
          *
-         * @return cost_modifier
+         * @return costModifier
          */
         public double getCostMod(){
-            return cost_modifier;
+            return costModifier;
         }
 
         /**

--- a/src/main/java/com/sucy/skill/manager/AttributeManager.java
+++ b/src/main/java/com/sucy/skill/manager/AttributeManager.java
@@ -238,7 +238,7 @@ public class AttributeManager {
             this.icon = Data.parseIcon(data);
             this.max = data.getInt(MAX, 999);
             // iomatix: base_cost and the modifier
-                // eg. per 0.3 increase -> 0.3=>0, 0.6=>0, 0.9=>0, 1.2=>1 (first additional cost point) etc.
+                // e.g. per 0.3 increase -> 0.3=>0, 0.6=>0, 0.9=>0, 1.2=>1 (first additional cost point) etc.
             this.cost_base = data.getInt(COSTBASE, 1);
             this.cost_modifier = data.getDouble(COSTMOD, 0.3);
 

--- a/src/main/resources/attributes.yml
+++ b/src/main/resources/attributes.yml
@@ -36,7 +36,7 @@ vitality:
   display: 'Vitality'
   max: 999
   cost_base: 1     # base attr points cost (starting value)
-  cost_modifier: 0.3 # increase attr points cost by
+  cost_modifier: 0.0 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 1
   icon-lore:
@@ -54,7 +54,7 @@ spirit:
   display: 'Spirit'
   max: 999
   cost_base: 1     # base attr points cost (starting value)
-  cost_modifier: 0.3 # increase attr points cost by
+  cost_modifier: 0.0 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 6
   icon-lore:
@@ -74,7 +74,7 @@ intelligence:
   display: 'Intelligence'
   max: 999
   cost_base: 1     # base attr points cost (starting value)
-  cost_modifier: 0.3 # increase attr points cost by
+  cost_modifier: 0.0 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 5
   icon-lore:
@@ -92,7 +92,7 @@ dexterity:
   display: 'Dexterity'
   max: 999
   cost_base: 1     # base attr points cost (starting value)
-  cost_modifier: 0.3 # increase attr points cost by
+  cost_modifier: 0.0 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 10
   icon-lore:
@@ -113,7 +113,7 @@ strength:
   display: 'Strength'
   max: 999
   cost_base: 1     # base attr points cost (starting value)
-  cost_modifier: 0.3 # increase attr points cost by
+  cost_modifier: 0.0 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 14
   icon-lore:

--- a/src/main/resources/attributes.yml
+++ b/src/main/resources/attributes.yml
@@ -27,9 +27,16 @@
 
 #   skill-damage-<classification>  | [PREM] The amount of damage done by skills with the specified classification
 #   skill-defense-<classification> | [PREM] The amount of damage taken by skills with the specified classification
+
+# iomatix proposes
+# 1. optional increase of attribute price in attr points
+#   so we'd need 2 more variables: cost_base (starting value) and cost_modifier (increases cost by floor((double)))
+
 vitality:
   display: 'Vitality'
   max: 999
+  cost_base: 1     # base attr points cost (starting value)
+  cost_modifier: 0.3 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 1
   icon-lore:
@@ -46,6 +53,8 @@ vitality:
 spirit:
   display: 'Spirit'
   max: 999
+  cost_base: 1     # base attr points cost (starting value)
+  cost_modifier: 0.3 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 6
   icon-lore:
@@ -64,6 +73,8 @@ spirit:
 intelligence:
   display: 'Intelligence'
   max: 999
+  cost_base: 1     # base attr points cost (starting value)
+  cost_modifier: 0.3 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 5
   icon-lore:
@@ -80,6 +91,8 @@ intelligence:
 dexterity:
   display: 'Dexterity'
   max: 999
+  cost_base: 1     # base attr points cost (starting value)
+  cost_modifier: 0.3 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 10
   icon-lore:
@@ -99,6 +112,8 @@ dexterity:
 strength:
   display: 'Strength'
   max: 999
+  cost_base: 1     # base attr points cost (starting value)
+  cost_modifier: 0.3 # increase attr points cost by
   icon: 'ink sack'
   icon-data: 14
   icon-lore:


### PR DESCRIPTION
Recreating the pull request after fixes regarding correct syntax this time to the dev branch.

The old request's contents message is below.
```
Hello,

I've implemented a minor update that introduces two new configuration parameters to the attributes.

cost_base & cost_modifier

Please have a look ~

Changes:
- Introduced (int) cost_base and (double) cost_modifier to the attributes.yml configuration file.
- Modified the AttributeManager to provide new values.
- Updated the upAttribute() function in the PlayerData class to accommodate the new values.
Small note: cost_modifier and floor(current*cost_base) are added up to calculate the current cost for each upgrade level
```