### PR TITLE
feat: No screen shake buff & damage

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/api/event/SkillDamageEvent.java
+++ b/src/main/java/studio/magemonkey/fabled/api/event/SkillDamageEvent.java
@@ -81,6 +81,9 @@ public class SkillDamageEvent extends Event implements Cancellable {
     private              boolean      knockback;
     @Getter
     private              boolean      ignoreDivinity;
+    @Getter
+    @Setter
+    private              boolean      noShake;
     private              boolean      cancelled = false;
 
     /**
@@ -93,9 +96,10 @@ public class SkillDamageEvent extends Event implements Cancellable {
      * @param classification the damage type to use
      * @param knockback      whether to apply knockback to the target
      * @param ignoreDivinity whether to ignore divinity
+     * @param noShake        whether to prevent screen shake
      */
     public SkillDamageEvent(Skill skill, LivingEntity damager, LivingEntity target, double damage,
-                            @Nullable String classification, boolean knockback, boolean ignoreDivinity) {
+                            @Nullable String classification, boolean knockback, boolean ignoreDivinity, boolean noShake) {
         this.skill = skill;
         this.damager = damager;
         this.target = target;
@@ -103,6 +107,7 @@ public class SkillDamageEvent extends Event implements Cancellable {
         this.classification = classification;
         this.knockback = knockback;
         this.ignoreDivinity = ignoreDivinity;
+        this.noShake = noShake;
     }
 
     /**

--- a/src/main/java/studio/magemonkey/fabled/api/skills/Skill.java
+++ b/src/main/java/studio/magemonkey/fabled/api/skills/Skill.java
@@ -56,8 +56,7 @@ import studio.magemonkey.fabled.api.event.TrueDamageEvent;
 import studio.magemonkey.fabled.api.player.PlayerCombos;
 import studio.magemonkey.fabled.api.player.PlayerData;
 import studio.magemonkey.fabled.api.player.PlayerSkill;
-import studio.magemonkey.fabled.api.util.DamageLoreRemover;
-import studio.magemonkey.fabled.api.util.Data;
+import studio.magemonkey.fabled.api.util.*;
 import studio.magemonkey.fabled.data.Permissions;
 import studio.magemonkey.fabled.dynamic.TempEntity;
 import studio.magemonkey.fabled.gui.tool.IconHolder;
@@ -822,6 +821,29 @@ public abstract class Skill implements IconHolder {
                        boolean knockback,
                        boolean ignoreDivinity,
                        EntityDamageEvent.DamageCause cause) {
+        damage(target, damage, source, classification, knockback, ignoreDivinity, cause, false);
+    }
+
+    /**
+     * Applies skill damage to the target, launching the skill damage event
+     *
+     * @param target         target to receive the damage
+     * @param damage         amount of damage to deal
+     * @param source         source of the damage (skill caster)
+     * @param classification type of damage to deal
+     * @param knockback      whether the damage should apply knockback
+     * @param ignoreDivinity whether the skill's damage should use divinity's overrides
+     * @param cause          the cause of the damage, might affect death messages
+     * @param noShake        whether to disable the screen shake effect when damaged
+     */
+    public void damage(LivingEntity target,
+                       double damage,
+                       LivingEntity source,
+                       String classification,
+                       boolean knockback,
+                       boolean ignoreDivinity,
+                       EntityDamageEvent.DamageCause cause,
+                       boolean noShake) {
         if (target instanceof TempEntity) {
             return;
         }
@@ -833,9 +855,8 @@ public abstract class Skill implements IconHolder {
         if (!Fabled.getSettings().canAttack(source, target, cause)) {
             return;
         }
-
         SkillDamageEvent event =
-                new SkillDamageEvent(this, source, target, damage, classification, knockback, ignoreDivinity);
+                new SkillDamageEvent(this, source, target, damage, classification, knockback, ignoreDivinity, noShake);
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
             return;
@@ -843,6 +864,7 @@ public abstract class Skill implements IconHolder {
 
         damage = event.getDamage();
         knockback = event.isKnockback();
+        noShake = event.isNoShake();
         target.setMetadata(MechanicListener.DAMAGE_CAUSE, new FixedMetadataValue(Fabled.inst(), cause));
         if (source instanceof Player) {
             if (PluginChecker.isNoCheatActive()) NoCheatHook.exempt((Player) source);
@@ -853,16 +875,13 @@ public abstract class Skill implements IconHolder {
         target.setNoDamageTicks(0);
         skillDamage = true;
 
-        if (knockback) {
-            if (!DamageRegistry.dealDamage(target, damage, classification, source))
-                target.damage(damage, source);
-        } else {
-            Vector velocity = target.getVelocity();
-            if (!DamageRegistry.dealDamage(target, damage, classification, source))
-                target.damage(damage, source);
+        Vector velocity = target.getVelocity();
+        if (noShake)
+            BuffManager.addBuff(target, BuffType.NO_SCREEN_SHAKE, new Buff("damage-" + classification, 0, false), 1);
+        if (!DamageRegistry.dealDamage(target, damage, classification, source))
+            target.damage(damage, source);
+        if (!knockback)
             target.setVelocity(velocity);
-        }
-
 
         // Reset damage timer to before the damage was applied
         target.setNoDamageTicks(ticks);

--- a/src/main/java/studio/magemonkey/fabled/api/util/BuffType.java
+++ b/src/main/java/studio/magemonkey/fabled/api/util/BuffType.java
@@ -39,7 +39,8 @@ public enum BuffType {
     SKILL_DAMAGE("FABLED_skill_damage"),
     SKILL_DEFENSE("FABLED_skill_defense"),
     HEALING("FABLED_healing"),
-    INVISIBILITY("FABLED_invisibility");
+    INVISIBILITY("FABLED_invisibility"),
+    NO_SCREEN_SHAKE("FABLED_no_screen_shake");
 
     private final String localizedName;
 

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DamageMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DamageMechanic.java
@@ -43,6 +43,7 @@ public class DamageMechanic extends MechanicComponent {
     private static final String KNOCKBACK       = "knockback";
     private static final String IGNORE_DIVINITY = "ignore-divinity";
     private static final String CAUSE           = "cause";
+    private static final String NO_SHAKE        = "no-shake";
 
     @Override
     public String getKey() {
@@ -59,6 +60,7 @@ public class DamageMechanic extends MechanicComponent {
         double  damage         = parseValues(caster, DAMAGE, level, 1.0);
         boolean knockback      = settings.getBool(KNOCKBACK, true);
         boolean ignoreDivinity = settings.getBool(IGNORE_DIVINITY, false);
+        boolean noShake        = settings.getBool(NO_SHAKE, false);
         String  classification = settings.getString(CLASSIFIER, "default");
         if (damage < 0) {
             return false;
@@ -87,7 +89,8 @@ public class DamageMechanic extends MechanicComponent {
                         ignoreDivinity,
                         EntityDamageEvent.DamageCause.valueOf(settings.getString(CAUSE, "Entity Attack")
                                 .toUpperCase(Locale.US)
-                                .replace(' ', '_')));
+                                .replace(' ', '_')),
+                        noShake);
             }
         }
         return !targets.isEmpty();

--- a/src/main/java/studio/magemonkey/fabled/listener/PacketListener.java
+++ b/src/main/java/studio/magemonkey/fabled/listener/PacketListener.java
@@ -31,6 +31,7 @@ public class PacketListener extends FabledListener {
     public void init() {
         protocolLib = new ProtocolLibHook(Fabled.inst());
         addListener(new EntityEquipmentPacketAdapter(ListenerPriority.HIGH, PacketType.Play.Server.ENTITY_EQUIPMENT));
+        addListener(new PlayAnimationPacketAdapter(ListenerPriority.HIGH, PacketType.Play.Server.HURT_ANIMATION));
     }
 
     private void addListener(PacketAdapter listener) {
@@ -63,6 +64,28 @@ public class PacketListener extends FabledListener {
     @Override
     public void cleanup() {
         protocolLib.unregister(packetListeners);
+    }
+
+    /**
+     * Used for no screen shake damages
+     */
+    private class PlayAnimationPacketAdapter extends PacketAdapter {
+
+        public PlayAnimationPacketAdapter(ListenerPriority listenerPriority, PacketType... types) {
+            super(Fabled.inst(), listenerPriority, types);
+        }
+
+        @Override
+        public void onPacketSending(PacketEvent event) {
+            Entity entity = protocolLib.getProtocolManager()
+                    .getEntityFromID(event.getPlayer().getWorld(), event.getPacket().getIntegers().read(0));
+            if (!(entity instanceof LivingEntity)) return;
+
+            BuffData data = BuffManager.getBuffData((LivingEntity) entity, false);
+            if (data == null || !data.isActive(BuffType.NO_SCREEN_SHAKE)) return;
+
+            event.setCancelled(true);
+        }
     }
 
     /**


### PR DESCRIPTION
A new buff that disables the screen shake animation upon damage, via packet cancelling.
Also made it an option for all damage-related events & mechanics & functions.