### PR TITLE
Fixed WarpMechanic's throughBlocks = false

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/api/target/TargetHelper.java
+++ b/src/main/java/studio/magemonkey/fabled/api/target/TargetHelper.java
@@ -292,8 +292,9 @@ public abstract class TargetHelper {
                         .getRelative(BlockFace.UP)
                         .getType())) {
                     lastValid = temp.clone();
-                } else
+                } else {
                     break;
+                }
                 temp.add(slope);
                 steps--;
             }


### PR DESCRIPTION
Previously if the destination is not a solid block, warp would warp to the destination disregarding the blocks in the middle
This PR makes it such that it stops mid way if it detects a solid block, which is how throughBlocks = false was supposed to work.