### PR TITLE
vibe coded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>fabled</artifactId>
-    <version>1.0.4-R0.92-SNAPSHOT</version>
+    <version>1.0.4-R0.90-SNAPSHOT</version>
     <name>Fabled</name>
     <description>A Minecraft Bukkit plugin aiming to provide an easy code API and skill editor for all server owners to
         create unique and fully custom classes and skills.
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>com.github.retrooper</groupId>
             <artifactId>packetevents-spigot</artifactId>
-            <version>2.12.1</version>
+            <version>2.11.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -137,6 +137,12 @@
             <groupId>studio.magemonkey</groupId>
             <artifactId>codex</artifactId>
             <version>${codex.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>studio.magemonkey</groupId>
+            <artifactId>divinity</artifactId>
+            <version>1.0.2-R0.57-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Test Dependencies -->
         <dependency>

--- a/src/main/java/studio/magemonkey/fabled/Fabled.java
+++ b/src/main/java/studio/magemonkey/fabled/Fabled.java
@@ -642,6 +642,8 @@ public class Fabled extends SkillAPI {
         listen(new ToolListener(), true);
         listen(new KillListener(), true);
         listen(new AddonListener(), true);
+        Bukkit.getPluginManager().registerEvents(
+                new studio.magemonkey.fabled.dynamic.condition.AttackIndicatorCondition.ShootListener(), this);
         listen(new ClickListener(), true);
         listen(new BarListener(), settings.isSkillBarEnabled());
         listen(new ComboListener(), settings.isCombosEnabled());

--- a/src/main/java/studio/magemonkey/fabled/api/classes/FabledClass.java
+++ b/src/main/java/studio/magemonkey/fabled/api/classes/FabledClass.java
@@ -54,7 +54,6 @@ import studio.magemonkey.fabled.log.Logger;
 import studio.magemonkey.fabled.tree.basic.InventoryTree;
 
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * Represents a template for a class used in the RPG system. This is
@@ -90,31 +89,31 @@ public abstract class FabledClass implements IconHolder {
     //                                                   //
     //                   Constructors                    //
     //                                                   //
-    /// ////////////////////////////////////////////////////
-    private final ReadOnlySettings    readOnlySettings = new ReadOnlySettings(settings);
+    ///////////////////////////////////////////////////////
+    private final ReadOnlySettings readOnlySettings = new ReadOnlySettings(settings);
     /**
      * Whether the class requires permissions
      * in order to be professed into
      */
     @Getter
-    protected     boolean             needsPermission;
+    protected     boolean          needsPermission;
     ///////////////////////////////////////////////////////
     //                                                   //
     //                 Accessor Methods                  //
     //                                                   //
-    /// ////////////////////////////////////////////////////
-    protected     String              actionBar        = "";
-    private       InventoryTree       skillTree;
-    private       String              parent;
-    private       Supplier<ItemStack> iconFn;
-    private       TreeType            tree;
-    private       String              name;
-    private       String              prefix;
-    private       String              group;
-    private       String              mana;
-    private       int                 maxLevel;
-    private       int                 expSources;
-    private       double              manaRegen;
+    ///////////////////////////////////////////////////////
+    protected     String           actionBar        = "";
+    private       InventoryTree    skillTree;
+    private       String           parent;
+    private       ItemStack        icon;
+    private       TreeType         tree;
+    private       String           name;
+    private       String           prefix;
+    private       String           group;
+    private       String           mana;
+    private       int              maxLevel;
+    private       int              expSources;
+    private       double           manaRegen;
 
     /**
      * Initializes a class template that does not profess from other
@@ -160,7 +159,7 @@ public abstract class FabledClass implements IconHolder {
      */
     protected FabledClass(String name, ItemStack icon, int maxLevel, String group, String parent) {
         this.parent = parent;
-        this.iconFn = () -> icon;
+        this.icon = icon;
         this.name = name;
         this.prefix = name;
         this.group = group == null ? "class" : group.toLowerCase();
@@ -272,7 +271,7 @@ public abstract class FabledClass implements IconHolder {
      * @return icon representation of the class
      */
     public ItemStack getIcon() {
-        return iconFn.get();
+        return icon;
     }
 
     /**
@@ -314,8 +313,8 @@ public abstract class FabledClass implements IconHolder {
      * @return GUI tool indicator
      */
     public ItemStack getToolIcon() {
-        ItemStack item     = new ItemStack(getIcon().getType());
-        ItemMeta  iconMeta = getIcon().getItemMeta();
+        ItemStack item     = new ItemStack(icon.getType());
+        ItemMeta  iconMeta = icon.getItemMeta();
         if (iconMeta != null) {
             ItemMeta     meta = item.getItemMeta();
             List<String> lore = iconMeta.hasLore() ? iconMeta.getLore() : new ArrayList<>();
@@ -629,7 +628,7 @@ public abstract class FabledClass implements IconHolder {
         }
         config.set(SKILLS, skillNames);
 
-        Data.serializeIcon(getIcon(), config);
+        Data.serializeIcon(icon, config);
         config.set(EXP, expSources);
 
         DataSection comboStartersSection = config.createSection("combo-starters");
@@ -661,19 +660,14 @@ public abstract class FabledClass implements IconHolder {
      */
     public void load(DataSection config) {
         parent = config.getString(PARENT);
+        icon = Data.parseIcon(config);
         name = config.getString(NAME, name);
 
-        iconFn = () -> {
-            ItemStack icon = Data.parseIcon(config);
-
-            ItemMeta iconMeta = icon.getItemMeta();
-            if (iconMeta != null && !iconMeta.hasDisplayName()) {
-                iconMeta.setDisplayName(name);
-                icon.setItemMeta(iconMeta);
-            }
-
-            return icon;
-        };
+        ItemMeta iconMeta = icon.getItemMeta();
+        if (iconMeta != null && !iconMeta.hasDisplayName()) {
+            iconMeta.setDisplayName(name);
+            icon.setItemMeta(iconMeta);
+        }
 
         actionBar = StringUT.color(config.getString(ACTION_BAR, ""));
         prefix = StringUT.color(config.getString(PREFIX, prefix));

--- a/src/main/java/studio/magemonkey/fabled/api/event/PlayerMaxManaChangeEvent.java
+++ b/src/main/java/studio/magemonkey/fabled/api/event/PlayerMaxManaChangeEvent.java
@@ -1,0 +1,41 @@
+package studio.magemonkey.fabled.api.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import studio.magemonkey.fabled.api.player.PlayerData;
+
+/**
+ * Fired after Fabled finishes calculating a player's max mana (including class bonuses and attribute scaling).
+ * Listeners may call {@link #setMaxMana(double)} to apply additional flat bonuses.
+ */
+public class PlayerMaxManaChangeEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private final        PlayerData  playerData;
+    private              double      maxMana;
+
+    public PlayerMaxManaChangeEvent(PlayerData playerData, double maxMana) {
+        this.playerData = playerData;
+        this.maxMana = maxMana;
+    }
+
+    public PlayerData getPlayerData() {
+        return playerData;
+    }
+
+    public double getMaxMana() {
+        return maxMana;
+    }
+
+    public void setMaxMana(double maxMana) {
+        this.maxMana = Math.max(0, maxMana);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
+++ b/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
@@ -2012,6 +2012,12 @@ public class PlayerData {
         this.maxHealth = this.scaleStat(AttributeManager.HEALTH, maxHealth);
         this.maxMana = this.scaleStat(AttributeManager.MANA, maxMana);
 
+        PlayerMaxManaChangeEvent maxManaEvent = new PlayerMaxManaChangeEvent(this, this.maxMana);
+        if (Bukkit.getPluginManager() != null) {
+            Bukkit.getPluginManager().callEvent(maxManaEvent);
+            this.maxMana = maxManaEvent.getMaxMana();
+        }
+
         this.mana = Math.min(mana, maxMana);
 
         // AsyncPlayerPreLoginEvent has to call this without player object to update Mana

--- a/src/main/java/studio/magemonkey/fabled/api/skills/Skill.java
+++ b/src/main/java/studio/magemonkey/fabled/api/skills/Skill.java
@@ -71,7 +71,6 @@ import studio.magemonkey.fabled.manager.AttributeManager;
 
 import java.text.DecimalFormat;
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * Represents a template for a skill used in the RPG system. This is
@@ -119,8 +118,14 @@ public abstract class Skill implements IconHolder {
     @Getter
     private final        String            key;
     private              List<String>      iconLore;
-
-    private Supplier<ItemStack> indicatorFn;
+    /**
+     * -- GETTER --
+     * Retrieves the indicator representing the skill for menus
+     *
+     * @return indicator for the skill
+     */
+    @Getter
+    private              ItemStack         indicator;
     /**
      * -- GETTER --
      * Retrieves the name of the skill
@@ -128,7 +133,7 @@ public abstract class Skill implements IconHolder {
      * @return skill name
      */
     @Getter
-    private String              name;
+    private              String            name;
     /**
      * -- GETTER --
      * Retrieves the descriptive type of the skill
@@ -136,7 +141,7 @@ public abstract class Skill implements IconHolder {
      * @return descriptive type of the skill
      */
     @Getter
-    private String              type;
+    private              String            type;
     /**
      * -- GETTER --
      * Retrieves the message for the skill to display when cast.
@@ -144,7 +149,7 @@ public abstract class Skill implements IconHolder {
      * @return cast message of the skill
      */
     @Getter
-    private String              message;
+    private              String            message;
     /**
      * -- GETTER --
      * Retrieves the skill required to be upgraded before this one
@@ -152,7 +157,7 @@ public abstract class Skill implements IconHolder {
      * @return required skill
      */
     @Getter
-    private String              skillReq;
+    private              String            skillReq;
     /**
      * -- GETTER --
      * Retrieves the max level the skill can reach
@@ -160,7 +165,7 @@ public abstract class Skill implements IconHolder {
      * @return max skill level
      */
     @Getter
-    private int                 maxLevel;
+    private              int               maxLevel;
     /**
      * -- GETTER --
      * Retrieves the level of the required skill needed to be obtained
@@ -169,10 +174,10 @@ public abstract class Skill implements IconHolder {
      * @return required skill level
      */
     @Getter
-    private int                 skillReqLevel;
-    private boolean             needsPermission;
-    private boolean             cooldownMessage;
-    private List<String>        incompatibleSkills;
+    private              int               skillReqLevel;
+    private              boolean           needsPermission;
+    private              boolean           cooldownMessage;
+    private              List<String>      incompatibleSkills;
     /**
      * -- GETTER --
      * Retrieves the ID of the skill's combo
@@ -184,7 +189,7 @@ public abstract class Skill implements IconHolder {
      */
     @Setter
     @Getter
-    private int                 combo;
+    private              int               combo;
 
     /**
      * Initializes a new skill that doesn't require any other skill.
@@ -286,10 +291,7 @@ public abstract class Skill implements IconHolder {
         this.key = name.toLowerCase();
         this.type = type;
         this.name = name;
-
-        ItemStack finalIndicator = indicator;
-        this.indicatorFn = () -> finalIndicator;
-
+        this.indicator = indicator;
         this.maxLevel = maxLevel;
         this.skillReq = skillReq;
         this.skillReqLevel = skillReqLevel;
@@ -297,15 +299,6 @@ public abstract class Skill implements IconHolder {
 
         this.message = Fabled.getLanguage().getMessage(NotificationNodes.CAST, true, FilterType.COLOR).get(0);
         this.iconLore = Fabled.getLanguage().getMessage(SkillNodes.LAYOUT, true, FilterType.COLOR);
-    }
-
-    /**
-     * Retrieves the indicator representing the skill for menus
-     *
-     * @return indicator for the skill
-     */
-    public ItemStack getIndicator() {
-        return indicatorFn.get();
     }
 
     /**
@@ -477,7 +470,7 @@ public abstract class Skill implements IconHolder {
      * @return GUI tool indicator
      */
     public ItemStack getToolIndicator() {
-        ItemStack item = indicatorFn.get();
+        ItemStack item = new ItemStack(indicator.getType());
         ItemMeta  meta = item.getItemMeta();
         if (meta != null) {
             List<String> lore = meta.hasLore() ? meta.getLore() : new ArrayList<>();
@@ -567,11 +560,20 @@ public abstract class Skill implements IconHolder {
     public ItemStack getIndicator(PlayerSkill skillData, boolean brief) {
         Player player = skillData.getPlayerData().getPlayer();
 
-        ItemStack item = indicatorFn.get();
+        ItemStack item = new ItemStack(indicator.getType());
         item.setAmount(Math.max(1, skillData.getLevel()));
         ItemMeta meta = item.hasItemMeta()
                 ? item.getItemMeta()
                 : Bukkit.getItemFactory().getItemMeta(item.getType());
+        ItemMeta iconMeta = indicator.getItemMeta();
+
+        if (meta instanceof Damageable) {
+            ((Damageable) meta).setDamage(((Damageable) iconMeta).getDamage());
+        }
+
+        if (iconMeta.hasCustomModelData()) {
+            meta.setCustomModelData(iconMeta.getCustomModelData());
+        }
 
         List<String> lore = new ArrayList<>();
 
@@ -873,20 +875,23 @@ public abstract class Skill implements IconHolder {
         target.setNoDamageTicks(0);
         skillDamage = true;
 
-        Vector velocity = target.getVelocity();
-        if (noShake)
-            BuffManager.addBuff(target, BuffType.NO_SCREEN_SHAKE, new Buff("damage-" + classification, 0, false), 1);
-        if (!DamageRegistry.dealDamage(target, damage, classification, source))
-            target.damage(damage, source);
-        if (!knockback)
-            target.setVelocity(velocity);
+        try {
+            Vector velocity = target.getVelocity();
+            if (noShake)
+                BuffManager.addBuff(target, BuffType.NO_SCREEN_SHAKE, new Buff("damage-" + classification, 0, false), 1);
+            if (!DamageRegistry.dealDamage(target, damage, classification, source))
+                target.damage(damage, source);
+            if (!knockback)
+                target.setVelocity(velocity);
 
-        // Reset damage timer to before the damage was applied
-        target.setNoDamageTicks(ticks);
-        if (source instanceof Player) {
-            if (PluginChecker.isNoCheatActive()) NoCheatHook.unexempt((Player) source);
+            // Reset damage timer to before the damage was applied
+            target.setNoDamageTicks(ticks);
+            if (source instanceof Player) {
+                if (PluginChecker.isNoCheatActive()) NoCheatHook.unexempt((Player) source);
+            }
+        } finally {
+            skillDamage = false;
         }
-        skillDamage = false;
     }
 
     /**
@@ -936,7 +941,7 @@ public abstract class Skill implements IconHolder {
         if (hasMessage()) {
             config.set(MSG, message.replace(ChatColor.COLOR_CHAR, '&'));
         }
-        Data.serializeIcon(getIndicator(), config);
+        Data.serializeIcon(indicator, config);
         config.set(DESC, description);
     }
 
@@ -962,7 +967,7 @@ public abstract class Skill implements IconHolder {
     public void load(DataSection config) {
         name = config.getString(NAME, name);
         type = StringUT.color(config.getString(TYPE, name));
-        indicatorFn = () -> Data.parseIcon(config);
+        indicator = Data.parseIcon(config);
         maxLevel = config.getInt(MAX, maxLevel);
         skillReq = config.getString(REQ);
         if (skillReq == null || skillReq.isEmpty()) skillReq = null;

--- a/src/main/java/studio/magemonkey/fabled/api/util/Data.java
+++ b/src/main/java/studio/magemonkey/fabled/api/util/Data.java
@@ -31,13 +31,8 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
-import studio.magemonkey.codex.CodexEngine;
-import studio.magemonkey.codex.api.items.ItemType;
-import studio.magemonkey.codex.api.items.exception.MissingItemException;
-import studio.magemonkey.codex.items.CodexItemManager;
 import studio.magemonkey.codex.mccore.config.parse.DataSection;
 import studio.magemonkey.codex.util.StringUT;
-import studio.magemonkey.fabled.Fabled;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,18 +49,12 @@ public class Data {
 
     private static ItemStack parse(final String mat, final int dur, final int data, final List<String> lore) {
         try {
-            CodexItemManager itemManager = CodexEngine.get().getItemManager();
-            ItemType         itemType    = null;
-            try {
-                itemType = itemManager.getItemType(mat);
-            } catch (MissingItemException mie) {
-            }
-            Material material = itemType == null ? Material.matchMaterial(mat) : null;
+            Material material = Material.matchMaterial(mat);
             if (material == null) {
                 material = Material.JACK_O_LANTERN;
             }
 
-            final ItemStack item = itemType != null ? itemType.create() : new ItemStack(material);
+            final ItemStack item = new ItemStack(material);
             final ItemMeta  meta = item.getItemMeta();
             if (meta != null) {
                 if (data != 0) {
@@ -95,13 +84,7 @@ public class Data {
      * @param config config to serialize into
      */
     public static void serializeIcon(ItemStack item, DataSection config) {
-        CodexItemManager itemManager = CodexEngine.get().getItemManager();
-        ItemType         itemType    = itemManager.getMainItemType(item);
-        if (itemType != null) {
-            config.set(MAT, itemType.getNamespacedID());
-        } else {
-            config.set(MAT, item.getType().name());
-        }
+        config.set(MAT, item.getType().name());
 
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {

--- a/src/main/java/studio/magemonkey/fabled/api/util/FlagManager.java
+++ b/src/main/java/studio/magemonkey/fabled/api/util/FlagManager.java
@@ -29,13 +29,22 @@ package studio.magemonkey.fabled.api.util;
 import org.bukkit.entity.LivingEntity;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The manager for temporary entity flag data
  */
 public class FlagManager {
-    private static final Map<Integer, FlagData> data = new HashMap<>();
+    private static final Map<Integer, FlagData> data            = new HashMap<>();
+    /**
+     * Guards against reentrant clearFlags calls on the same entity.
+     * Prevents infinite recursion when FlagExpireTrigger skills add new flags
+     * during flag-clearing (e.g., on player death), which would re-create a
+     * FlagData entry and cause clearFlags → clear → removeFlag → clearFlags → ∞.
+     */
+    private static final Set<Integer>           clearingEntities = new HashSet<>();
 
     /**
      * Retrieves the flag data for an entity. This creates new data if
@@ -128,9 +137,21 @@ public class FlagManager {
         if (entity == null) {
             return;
         }
-        FlagData result = data.remove(entity.getEntityId());
-        if (result != null) {
-            result.clear();
+        // Guard against reentrant calls on the same entity.
+        // FlagExpireTrigger skills may call addFlag during clearing,
+        // re-creating a FlagData entry; without this guard that would
+        // cause infinite recursion (clearFlags → clear → removeFlag → clearFlags …).
+        int id = entity.getEntityId();
+        if (!clearingEntities.add(id)) {
+            return; // already being cleared — skip
+        }
+        try {
+            FlagData result = data.remove(id);
+            if (result != null) {
+                result.clear();
+            }
+        } finally {
+            clearingEntities.remove(id);
         }
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/ComponentRegistry.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/ComponentRegistry.java
@@ -98,6 +98,7 @@ public class ComponentRegistry {
         register(new RememberTarget());
         register(new SelfTarget());
         register(new SingleTarget());
+        register(new WorldTarget());
 
         // Conditions
         register(new ActionBarCondition());

--- a/src/main/java/studio/magemonkey/fabled/dynamic/condition/AttackIndicatorCondition.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/condition/AttackIndicatorCondition.java
@@ -1,11 +1,71 @@
 package studio.magemonkey.fabled.dynamic.condition;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.CrossbowMeta;
+import org.bukkit.metadata.FixedMetadataValue;
+import studio.magemonkey.fabled.Fabled;
 
 public class AttackIndicatorCondition extends ConditionComponent {
-    private static final String MIN = "min";
-    private static final String MAX = "max";
+    private static final String MIN    = "min";
+    private static final String MAX    = "max";
+    private static final String WEAPON = "weapon";
+
+    // Metadata key — set by ShootListener when player fires bow/crossbow.
+    // Read by getIndicatorValue when normal polling fails (post-launch state).
+    private static final String LAST_SHOOT_FORCE_META = "fabled_last_shoot_force";
+
+    // Paper-only APIs accessed via reflection — runtime is Paper, but compile classpath is Spigot.
+    private static java.lang.reflect.Method ACTIVE_ITEM_METHOD;
+    private static java.lang.reflect.Method IS_CHARGED_METHOD;
+
+    private static ItemStack getActiveItemSafe(Player player) {
+        try {
+            if (ACTIVE_ITEM_METHOD == null) {
+                ACTIVE_ITEM_METHOD = Player.class.getMethod("getActiveItem");
+            }
+            return (ItemStack) ACTIVE_ITEM_METHOD.invoke(player);
+        } catch (Throwable ignored) {
+            return player.getInventory().getItemInMainHand();
+        }
+    }
+
+    private static boolean isChargedSafe(CrossbowMeta meta) {
+        try {
+            if (IS_CHARGED_METHOD == null) {
+                IS_CHARGED_METHOD = CrossbowMeta.class.getMethod("isCharged");
+            }
+            return (Boolean) IS_CHARGED_METHOD.invoke(meta);
+        } catch (Throwable ignored) {
+            return meta.hasChargedProjectiles();
+        }
+    }
+
+    /**
+     * Static listener that captures bow/crossbow shoot force as metadata on the shooter.
+     * EntityShootBowEvent fires BEFORE ProjectileLaunchEvent (Launch trigger). Metadata is
+     * read by AttackIndicator on the same tick, then cleared one tick later.
+     */
+    public static class ShootListener implements Listener {
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onShoot(EntityShootBowEvent e) {
+            if (!(e.getEntity() instanceof Player)) return;
+            final Player p = (Player) e.getEntity();
+            p.setMetadata(LAST_SHOOT_FORCE_META,
+                    new FixedMetadataValue(Fabled.inst(), (double) e.getForce()));
+            Bukkit.getScheduler().runTaskLater(Fabled.inst(),
+                    () -> p.removeMetadata(LAST_SHOOT_FORCE_META, Fabled.inst()), 1L);
+        }
+    }
 
     @Override
     public String getKey() {
@@ -15,12 +75,57 @@ public class AttackIndicatorCondition extends ConditionComponent {
     @Override
     public boolean test(LivingEntity caster, int level, LivingEntity target) {
         double min = parseValues(target, MIN, level, settings.getFloat(MIN, 0));
-        double max = parseValues(target, MAX, level, settings.getFloat(MAX, 0));
+        double max = parseValues(target, MAX, level, settings.getFloat(MAX, 1));
 
         if (!(caster instanceof Player))
             return false;
         Player player = (Player) caster;
 
-        return player.getAttackCooldown() >= min && player.getAttackCooldown() <= max;
+        double value = getIndicatorValue(player);
+        return value >= min && value <= max;
+    }
+
+    private double getIndicatorValue(Player player) {
+        String weapon = settings.getString(WEAPON, "auto").toLowerCase();
+        ItemStack main = player.getInventory().getItemInMainHand();
+        Material type = main.getType();
+
+        // Post-launch path — Launch trigger fires after release/fire, so polling player state
+        // returns 0. Use force snapshot captured by ShootListener on EntityShootBowEvent.
+        if (player.hasMetadata(LAST_SHOOT_FORCE_META)) {
+            try {
+                if ((weapon.equals("auto") && (type == Material.BOW || type == Material.CROSSBOW))
+                        || weapon.equals("bow") || weapon.equals("crossbow")) {
+                    return Math.min(1.0, player.getMetadata(LAST_SHOOT_FORCE_META).get(0).asDouble());
+                }
+            } catch (Exception ignored) { /* fall through to polling path */ }
+        }
+
+        if (weapon.equals("bow") || (weapon.equals("auto") && type == Material.BOW)) {
+            if (!player.isHandRaised() || getActiveItemSafe(player).getType() != Material.BOW)
+                return 0.0;
+            return Math.min(1.0, player.getItemInUseTicks() / 20.0);
+        }
+
+        if (weapon.equals("crossbow") || (weapon.equals("auto") && type == Material.CROSSBOW)) {
+            ItemStack crossbow = (type == Material.CROSSBOW) ? main : player.getInventory().getItemInOffHand();
+            if (crossbow.getType() != Material.CROSSBOW)
+                return 0.0;
+            if (crossbow.getItemMeta() instanceof CrossbowMeta) {
+                CrossbowMeta meta = (CrossbowMeta) crossbow.getItemMeta();
+                if (isChargedSafe(meta))
+                    return 1.0;
+            }
+            // Partially loaded (player is drawing crossbow)
+            if (player.isHandRaised() && getActiveItemSafe(player).getType() == Material.CROSSBOW) {
+                Enchantment quickCharge = Enchantment.getByKey(NamespacedKey.minecraft("quick_charge"));
+                int qcLevel = (quickCharge != null) ? crossbow.getEnchantmentLevel(quickCharge) : 0;
+                int loadTicks = Math.max(5, 25 - qcLevel * 5);
+                return Math.min(1.0, player.getItemInUseTicks() / (double) loadTicks);
+            }
+            return 0.0;
+        }
+
+        return player.getAttackCooldown();
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/condition/FlagCondition.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/condition/FlagCondition.java
@@ -38,7 +38,7 @@ public class FlagCondition extends ConditionComponent {
 
     @Override
     boolean test(final LivingEntity caster, final int level, final LivingEntity target) {
-        final String  flag = settings.getString(KEY);
+        final String  flag = filter(caster, target, settings.getString(KEY));
         final boolean set  = !settings.getString(TYPE, "set").toLowerCase().equals("not set");
         return FlagManager.hasFlag(target, flag) == set;
     }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DamageMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DamageMechanic.java
@@ -28,6 +28,8 @@ package studio.magemonkey.fabled.dynamic.mechanic;
 
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import studio.magemonkey.fabled.Fabled;
 
 import java.util.List;
 import java.util.Locale;
@@ -44,6 +46,14 @@ public class DamageMechanic extends MechanicComponent {
     private static final String IGNORE_DIVINITY = "ignore-divinity";
     private static final String CAUSE           = "cause";
     private static final String NO_SHAKE        = "no-shake";
+    private static final String IGNORE_CRIT     = "divinity-ignore-crit";
+    private static final String IGNORE_DODGE    = "divinity-ignore-dodge";
+    private static final String IGNORE_BLOCK    = "divinity-ignore-block";
+    private static final String NO_BLEED        = "divinity-no-bleed";
+    private static final String NO_VAMP         = "divinity-no-vamp";
+    private static final String IGNORE_SKILL_CRIT  = "ignore-skill-crit";
+
+    static final String DMG_FLAGS_META = "fabled_dmg_flags";
 
     @Override
     public String getKey() {
@@ -65,34 +75,51 @@ public class DamageMechanic extends MechanicComponent {
         if (damage < 0) {
             return false;
         }
-        for (LivingEntity target : targets) {
-            if (target.isDead()) {
-                continue;
-            }
 
-            double amount = damage;
-            if (percent) {
-                amount = damage * target.getMaxHealth() / 100;
-            } else if (missing) {
-                amount = damage * (target.getMaxHealth() - target.getHealth()) / 100;
-            } else if (left) {
-                amount = damage * target.getHealth() / 100;
+        int dmgFlags = 0;
+        if (settings.getBool(IGNORE_CRIT,  false)) dmgFlags |= 0x01;
+        if (settings.getBool(IGNORE_DODGE, false)) dmgFlags |= 0x02;
+        if (settings.getBool(IGNORE_BLOCK, false)) dmgFlags |= 0x04;
+        if (settings.getBool(NO_BLEED,     false)) dmgFlags |= 0x08;
+        if (settings.getBool(NO_VAMP,      false)) dmgFlags |= 0x10;
+        if (settings.getBool(IGNORE_SKILL_CRIT, false)) dmgFlags |= 0x20;
+        if (dmgFlags != 0)
+            caster.setMetadata(DMG_FLAGS_META, new FixedMetadataValue(Fabled.inst(), dmgFlags));
+
+        try {
+            for (LivingEntity target : targets) {
+                if (target.isDead()) {
+                    continue;
+                }
+
+                double amount = damage;
+                if (percent) {
+                    amount = damage * target.getMaxHealth() / 100;
+                } else if (missing) {
+                    amount = damage * (target.getMaxHealth() - target.getHealth()) / 100;
+                } else if (left) {
+                    amount = damage * target.getHealth() / 100;
+                }
+                if (trueDmg) {
+                    skill.trueDamage(target, amount, caster);
+                } else {
+                    skill.damage(target,
+                            amount,
+                            caster,
+                            classification,
+                            knockback,
+                            ignoreDivinity,
+                            EntityDamageEvent.DamageCause.valueOf(settings.getString(CAUSE, "Entity Attack")
+                                    .toUpperCase(Locale.US)
+                                    .replace(' ', '_')),
+                            noShake);
+                }
             }
-            if (trueDmg) {
-                skill.trueDamage(target, amount, caster);
-            } else {
-                skill.damage(target,
-                        amount,
-                        caster,
-                        classification,
-                        knockback,
-                        ignoreDivinity,
-                        EntityDamageEvent.DamageCause.valueOf(settings.getString(CAUSE, "Entity Attack")
-                                .toUpperCase(Locale.US)
-                                .replace(' ', '_')),
-                        noShake);
-            }
+        } finally {
+            if (dmgFlags != 0)
+                caster.removeMetadata(DMG_FLAGS_META, Fabled.inst());
         }
+
         return !targets.isEmpty();
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DurabilityMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DurabilityMechanic.java
@@ -6,6 +6,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import studio.magemonkey.divinity.stats.items.ItemStats;
+import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
+import studio.magemonkey.divinity.stats.items.attributes.stats.DurabilityStat;
 
 import java.util.List;
 
@@ -59,6 +62,14 @@ public class DurabilityMechanic extends MechanicComponent {
         }
         im.setDamage(im.getDamage() + amount);
         item.setItemMeta(im);
+
+        try {
+            DurabilityStat duraStat = (DurabilityStat) ItemStats.getStat(TypedStat.Type.DURABILITY);
+            if (duraStat != null && ItemStats.hasStat(item, player, TypedStat.Type.DURABILITY)) {
+                duraStat.reduceDurability(player, item, amount);
+            }
+        } catch (Exception ignored) { /* Divinity not loaded */ }
+
         return true;
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagClearMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagClearMechanic.java
@@ -63,18 +63,21 @@ public class FlagClearMechanic extends MechanicComponent {
             return false;
         }
 
-        String  key      = settings.getString(KEY);
+        String  rawKey   = settings.getString(KEY);
         boolean useRegex = settings.getBool(REGEX, false);
+        boolean hadError = false;
 
         if (useRegex) {
-            Pattern pattern;
-            try {
-                pattern = Pattern.compile(key);
-            } catch (PatternSyntaxException e) {
-                Fabled.inst().getLogger().warning("Invalid regex pattern for flag clear mechanic: \"" + key + "\" - " + e.getDescription());
-                return false;
-            }
             for (LivingEntity target : targets) {
+                String key = filter(caster, target, rawKey);
+                Pattern pattern;
+                try {
+                    pattern = Pattern.compile(key);
+                } catch (PatternSyntaxException e) {
+                    Fabled.inst().getLogger().warning("Invalid regex pattern for flag clear mechanic: \"" + key + "\" - " + e.getDescription());
+                    hadError = true;
+                    continue;
+                }
                 FlagData data = FlagManager.getFlagData(target, false);
                 if (data != null) {
                     new HashSet<>(data.flagList()).stream()
@@ -84,9 +87,10 @@ public class FlagClearMechanic extends MechanicComponent {
             }
         } else {
             for (LivingEntity target : targets) {
+                String key = filter(caster, target, rawKey);
                 FlagManager.removeFlag(target, key);
             }
         }
-        return targets.size() > 0;
+        return targets.size() > 0 && !hadError;
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagMechanic.java
@@ -58,10 +58,11 @@ public class FlagMechanic extends MechanicComponent {
             return false;
         }
 
-        String key     = settings.getString(KEY);
+        String rawKey  = settings.getString(KEY);
         double seconds = parseValues(caster, SECONDS, level, 3.0);
         int    ticks   = (int) (seconds * 20);
         for (LivingEntity target : targets) {
+            String key = filter(caster, target, rawKey);
             FlagManager.addFlag(target, key, ticks);
         }
         return targets.size() > 0;

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagToggleMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagToggleMechanic.java
@@ -57,8 +57,9 @@ public class FlagToggleMechanic extends MechanicComponent {
             return false;
         }
 
-        String key = settings.getString(KEY);
+        String rawKey = settings.getString(KEY);
         for (LivingEntity target : targets) {
+            String key = filter(caster, target, rawKey);
             if (FlagManager.hasFlag(target, key)) {
                 FlagManager.removeFlag(target, key);
             } else {

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/HealMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/HealMechanic.java
@@ -28,6 +28,8 @@ package studio.magemonkey.fabled.dynamic.mechanic;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
+import studio.magemonkey.divinity.stats.EntityStats;
+import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 import studio.magemonkey.fabled.api.event.SkillHealEvent;
 
 import java.util.List;
@@ -36,8 +38,10 @@ import java.util.List;
  * Heals each target
  */
 public class HealMechanic extends MechanicComponent {
-    private static final String TYPE  = "type";
-    private static final String VALUE = "value";
+    private static final String TYPE                    = "type";
+    private static final String VALUE                   = "value";
+    private static final String IGNORE_HEALING_CAST     = "ignore-healing-cast";
+    private static final String IGNORE_HEALING_RECEIVED = "ignore-healing-received";
 
     @Override
     public String getKey() {
@@ -46,8 +50,10 @@ public class HealMechanic extends MechanicComponent {
 
     @Override
     public boolean execute(LivingEntity caster, int level, List<LivingEntity> targets, boolean force) {
-        boolean percent = settings.getString(TYPE, "health").toLowerCase().equals("percent");
-        double  value   = parseValues(caster, VALUE, level, 1.0);
+        boolean percent              = settings.getString(TYPE, "health").toLowerCase().equals("percent");
+        double  value                = parseValues(caster, VALUE, level, 1.0);
+        boolean ignoreHealingCast    = settings.getBool(IGNORE_HEALING_CAST, false);
+        boolean ignoreHealingReceived = settings.getBool(IGNORE_HEALING_RECEIVED, false);
         if (value < 0) {
             return false;
         }
@@ -59,6 +65,20 @@ public class HealMechanic extends MechanicComponent {
             double amount = value;
             if (percent) {
                 amount = target.getMaxHealth() * value / 100;
+            }
+
+            if (!ignoreHealingCast) {
+                try {
+                    double healCast = EntityStats.get(caster).getItemStat(TypedStat.Type.HEALING_CAST, false);
+                    if (healCast != 0) amount *= (1.0 + healCast / 100.0);
+                } catch (Exception ignored) { /* Divinity not loaded */ }
+            }
+
+            if (!ignoreHealingReceived) {
+                try {
+                    double healReceived = EntityStats.get(target).getItemStat(TypedStat.Type.HEALING_RECEIVED, false);
+                    if (healReceived != 0) amount *= (1.0 + healReceived / 100.0);
+                } catch (Exception ignored) { /* Divinity not loaded */ }
             }
 
             SkillHealEvent event = new SkillHealEvent(caster, target, amount);

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RepeatMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RepeatMechanic.java
@@ -39,10 +39,11 @@ import java.util.Map;
  * Executes child components multiple times
  */
 public class RepeatMechanic extends MechanicComponent {
-    private static final String REPETITIONS  = "repetitions";
-    private static final String DELAY        = "delay";
-    private static final String PERIOD       = "period";
-    private static final String STOP_ON_FAIL = "stop-on-fail";
+    private static final String REPETITIONS     = "repetitions";
+    private static final String DELAY           = "delay";
+    private static final String PERIOD          = "period";
+    private static final String STOP_ON_FAIL    = "stop-on-fail";
+    private static final String SINGLE_INSTANCE = "single-instance";
 
     private final Map<Integer, List<RepeatTask>> tasks = new HashMap<>();
 
@@ -63,9 +64,19 @@ public class RepeatMechanic extends MechanicComponent {
                 return false;
             }
 
-            final int     delay      = (int) (settings.getDouble(DELAY, 0.0) * 20);
-            final int     period     = (int) (settings.getDouble(PERIOD, 1.0) * 20);
-            final boolean stopOnFail = settings.getBool(STOP_ON_FAIL, false);
+            final int     delay          = (int) (settings.getDouble(DELAY, 0.0) * 20);
+            final int     period         = (int) (settings.getDouble(PERIOD, 1.0) * 20);
+            final boolean stopOnFail     = settings.getBool(STOP_ON_FAIL, false);
+            final boolean singleInstance = settings.getBool(SINGLE_INSTANCE, false);
+
+            // Cancel all existing tasks for this caster when single-instance is enabled
+            if (singleInstance) {
+                final List<RepeatTask> existing = tasks.remove(caster.getEntityId());
+                if (existing != null) {
+                    existing.forEach(RepeatTask::cancel);
+                }
+            }
+
             if (period <= 0) {
                 // 0 tick loop
                 while (count > 0) {

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatMechanic.java
@@ -35,6 +35,8 @@ import studio.magemonkey.fabled.Fabled;
 import studio.magemonkey.fabled.api.enums.Operation;
 import studio.magemonkey.fabled.api.player.PlayerData;
 import studio.magemonkey.fabled.api.player.PlayerStatModifier;
+import studio.magemonkey.fabled.hook.DivinityHook;
+import studio.magemonkey.fabled.hook.PluginChecker;
 
 import java.util.HashMap;
 import java.util.List;
@@ -44,13 +46,15 @@ import java.util.Map;
  * Applies a flag to each target
  */
 public class StatMechanic extends MechanicComponent {
-    private static final String KEY       = "key";
-    private static final String OPERATION = "operation";
-    private static final String AMOUNT    = "amount";
-    private static final String SECONDS   = "seconds";
-    private static final String STACKABLE = "stackable";
+    private static final String KEY               = "key";
+    private static final String OPERATION         = "operation";
+    private static final String AMOUNT            = "amount";
+    private static final String SECONDS           = "seconds";
+    private static final String STACKABLE         = "stackable";
+    private static final String IGNORE_DIVINITY_CAP = "ignore-divinity-cap";
 
-    private final Map<Integer, Map<String, StatTask>> tasks = new HashMap<>();
+    private final Map<Integer, Map<String, StatTask>> tasks      = new HashMap<>();
+    private final Map<Integer, Map<Integer, Object>>  mobEffects = new HashMap<>();
 
     @Override
     public String getKey() {
@@ -63,6 +67,7 @@ public class StatMechanic extends MechanicComponent {
         if (casterTasks != null) {
             casterTasks.values().forEach(StatTask::stop);
         }
+        mobEffects.remove(user.getEntityId());
     }
 
     @Override
@@ -78,13 +83,25 @@ public class StatMechanic extends MechanicComponent {
         final boolean               stackable   = settings.getBool(STACKABLE, false);
         final int                   ticks       = (int) (seconds * 20);
         final String                operation   = settings.getString(OPERATION, "MULTIPLY_PERCENTAGE");
+        final boolean               ignoreCap   = settings.getBool(IGNORE_DIVINITY_CAP, false);
 
         boolean worked = false;
         for (LivingEntity target : targets) {
             if (target instanceof Player) {
                 worked = true;
                 final PlayerData data = Fabled.getData((Player) target);
-                PlayerStatModifier modifier = new PlayerStatModifier("fabled.mechanic.stat_mechanic", amount,
+
+                double effectiveAmount = amount;
+                if (!ignoreCap && PluginChecker.isDivinityActive()) {
+                    try {
+                        effectiveAmount = DivinityHook.clampStatAmount(
+                                key, Operation.valueOf(operation), amount, (Player) target);
+                    } catch (Exception ignored) {
+                        // safe fallback: use original amount
+                    }
+                }
+
+                PlayerStatModifier modifier = new PlayerStatModifier("fabled.mechanic.stat_mechanic", effectiveAmount,
                         Operation.valueOf(operation), false);
 
                 if (casterTasks.containsKey(data.getPlayerName()) && !stackable) {
@@ -94,7 +111,7 @@ public class StatMechanic extends MechanicComponent {
 
                     data.addStatModifier(key, modifier, true);
 
-                    old.cancel();
+                    old.stop(); // use stop() instead of cancel() — cancel() throws ISE when seconds:-1 (task never scheduled)
                 } else {
                     data.addStatModifier(key, modifier, true);
                 }
@@ -103,6 +120,29 @@ public class StatMechanic extends MechanicComponent {
                 casterTasks.put(data.getPlayerName(), task);
                 if (ticks >= 0) {
                     Fabled.schedule(task, ticks);
+                }
+            } else if (PluginChecker.isDivinityActive()) {
+                Object effect = DivinityHook.applyStatToMob(target, caster, key, operation, amount, seconds);
+                if (effect == null) continue;
+
+                worked = true;
+                final Map<Integer, Object> casterMobEffects =
+                        mobEffects.computeIfAbsent(caster.getEntityId(), HashMap::new);
+                final int targetId = target.getEntityId();
+
+                if (casterMobEffects.containsKey(targetId) && !stackable) {
+                    DivinityHook.removeStatFromMob(target, casterMobEffects.remove(targetId));
+                }
+
+                casterMobEffects.put(targetId, effect);
+
+                if (ticks >= 0) {
+                    Fabled.schedule(new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            casterMobEffects.remove(targetId);
+                        }
+                    }, ticks);
                 }
             }
         }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatusMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatusMechanic.java
@@ -27,6 +27,8 @@
 package studio.magemonkey.fabled.dynamic.mechanic;
 
 import org.bukkit.entity.LivingEntity;
+import studio.magemonkey.divinity.stats.EntityStats;
+import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 import studio.magemonkey.fabled.api.util.FlagManager;
 
 import java.util.List;
@@ -35,8 +37,10 @@ import java.util.List;
  * Applies a flag to each target
  */
 public class StatusMechanic extends MechanicComponent {
-    private static final String KEY      = "status";
-    private static final String DURATION = "duration";
+    private static final String KEY              = "status";
+    private static final String DURATION         = "duration";
+    private static final String IGNORE_CC_RES    = "ignore-cc-resistance";
+    private static final String IGNORE_CC_DUR    = "ignore-cc-duration";
 
     @Override
     public String getKey() {
@@ -49,10 +53,32 @@ public class StatusMechanic extends MechanicComponent {
             return false;
         }
 
-        String key     = settings.getString(KEY, "stun").toLowerCase();
-        double seconds = parseValues(caster, DURATION, level, 3.0);
-        int    ticks   = (int) (seconds * 20);
+        String  key           = settings.getString(KEY, "stun").toLowerCase();
+        double  seconds       = parseValues(caster, DURATION, level, 3.0);
+        boolean ignoreCCRes   = settings.getBool(IGNORE_CC_RES, false);
+        boolean ignoreCCDur   = settings.getBool(IGNORE_CC_DUR, false);
+        int baseTicks = (int) (seconds * 20);
+        if (!ignoreCCDur) {
+            try {
+                EntityStats casterStats = EntityStats.get(caster);
+                double      ccDuration  = casterStats.getItemStat(TypedStat.Type.CC_DURATION, false);
+                if (ccDuration != 0) {
+                    baseTicks = (int) (baseTicks * (1.0 + ccDuration / 100.0));
+                }
+            } catch (Exception ignored) { /* Divinity not loaded */ }
+        }
+
         for (LivingEntity target : targets) {
+            int ticks = baseTicks;
+            if (!ignoreCCRes) {
+                try {
+                    EntityStats stats      = EntityStats.get(target);
+                    double      resistance = stats.getItemStat(TypedStat.Type.CC_RESISTANCE, false);
+                    if (resistance > 0) {
+                        ticks = (int) (ticks * (1.0 - resistance / 100.0));
+                    }
+                } catch (Exception ignored) { /* Divinity not loaded */ }
+            }
             FlagManager.addFlag(target, key, ticks);
         }
         return !targets.isEmpty();

--- a/src/main/java/studio/magemonkey/fabled/dynamic/target/TargetComponent.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/target/TargetComponent.java
@@ -116,7 +116,7 @@ public abstract class TargetComponent extends EffectComponent {
         if (target instanceof Player && (((Player) target).getGameMode() == GameMode.SPECTATOR
                 || ((Player) target).getGameMode() == GameMode.CREATIVE)) return false;
 
-        return target != caster && Fabled.getSettings().isValidTarget(target) && (throughWall
+        return (self != IncludeCaster.FALSE || target != caster) && Fabled.getSettings().isValidTarget(target) && (throughWall
                 || !TargetHelper.isObstructed(from.getEyeLocation(), target.getEyeLocation())) && (everyone
                 || allies == Fabled.getSettings().isAlly(caster, target));
     }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/FlagExpireTrigger.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/FlagExpireTrigger.java
@@ -4,8 +4,11 @@ import org.bukkit.entity.LivingEntity;
 import studio.magemonkey.fabled.api.CastData;
 import studio.magemonkey.fabled.api.Settings;
 import studio.magemonkey.fabled.api.event.FlagExpireEvent;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FlagExpireTrigger implements Trigger<FlagExpireEvent> {
 
@@ -30,9 +33,34 @@ public class FlagExpireTrigger implements Trigger<FlagExpireEvent> {
      */
     @Override
     public boolean shouldTrigger(final FlagExpireEvent event, final int level, final Settings settings) {
-        final List<String> flags = settings.getStringList("flags");
-        final boolean inverted  = settings.getBool("inverted", false);
-        return (flags.isEmpty() || flags.contains("Any") || flags.contains(event.getFlag())) != inverted;
+        final List<String> flags    = settings.getStringList("flags");
+        final boolean      inverted = settings.getBool("inverted", false);
+
+        final LivingEntity entity = getCaster(event);
+        return (flags.isEmpty()
+                || flags.contains("Any")
+                || flags.stream().anyMatch(f -> filterFlag(entity, f).equals(event.getFlag()))) != inverted;
+    }
+
+    /**
+     * Resolves dynamic variables in a flag name using the given entity's cast data.
+     * Mirrors EffectComponent#filter — entity acts as both caster and target.
+     * Note: for cross-entity skills {player} resolves to the entity whose flag
+     * expired, not the original caster.
+     */
+    private String filterFlag(final LivingEntity entity, String text) {
+        CastData data  = DynamicSkill.getCastData(entity);
+        Pattern  pat   = Pattern.compile("\\{[^{}]+}");
+        Matcher  match = pat.matcher(text);
+        while (match.find()) {
+            String key = match.group().substring(1, match.group().length() - 1);
+            if (data.contains(key))            text = text.replace(match.group(), data.get(key));
+            else if (key.equals("player"))     text = text.replace(match.group(), entity.getName());
+            else if (key.equals("target"))     text = text.replace(match.group(), entity.getName());
+            else if (key.equals("targetUUID")) text = text.replace(match.group(), entity.getUniqueId().toString());
+            match = pat.matcher(text);
+        }
+        return text;
     }
 
     /**
@@ -41,7 +69,7 @@ public class FlagExpireTrigger implements Trigger<FlagExpireEvent> {
     // Removes flag duration as a usable Value if it is set
     @Override
     public void setValues(final FlagExpireEvent event, final CastData data) {
-        data.remove("api-"+event.getFlag()+"-duration");
+        data.remove("api-" + event.getFlag() + "-duration");
     }
 
     /**

--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/FlagTrigger.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/FlagTrigger.java
@@ -4,8 +4,11 @@ import org.bukkit.entity.LivingEntity;
 import studio.magemonkey.fabled.api.CastData;
 import studio.magemonkey.fabled.api.Settings;
 import studio.magemonkey.fabled.api.event.FlagApplyEvent;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FlagTrigger implements Trigger<FlagApplyEvent> {
 
@@ -30,16 +33,41 @@ public class FlagTrigger implements Trigger<FlagApplyEvent> {
      */
     @Override
     public boolean shouldTrigger(final FlagApplyEvent event, final int level, final Settings settings) {
-        final List<String> flags = settings.getStringList("flags");
-        final boolean inverted  = settings.getBool("inverted", false);
-        final double minDuration = settings.getDouble("min-duration", 0);
-        final int ticks = (int) minDuration * 20;
+        final List<String> flags       = settings.getStringList("flags");
+        final boolean      inverted    = settings.getBool("inverted", false);
+        final double       minDuration = settings.getDouble("min-duration", 0);
+        final int          ticks       = (int) (minDuration * 20);
 
-        // Return False if the Flaf 
-        if (event.getTicks() < ticks){
+        // Return false if the flag duration is shorter than the required minimum
+        if (event.getTicks() < ticks) {
             return false;
-        };
-        return (flags.isEmpty() || flags.contains("Any") || flags.contains(event.getFlag())) != inverted;
+        }
+
+        final LivingEntity entity = getCaster(event);
+        return (flags.isEmpty()
+                || flags.contains("Any")
+                || flags.stream().anyMatch(f -> filterFlag(entity, f).equals(event.getFlag()))) != inverted;
+    }
+
+    /**
+     * Resolves dynamic variables in a flag name using the given entity's cast data.
+     * Mirrors EffectComponent#filter — entity acts as both caster and target.
+     * Note: for cross-entity skills {player} resolves to the entity that received
+     * the flag, not the original caster.
+     */
+    private String filterFlag(final LivingEntity entity, String text) {
+        CastData data  = DynamicSkill.getCastData(entity);
+        Pattern  pat   = Pattern.compile("\\{[^{}]+}");
+        Matcher  match = pat.matcher(text);
+        while (match.find()) {
+            String key = match.group().substring(1, match.group().length() - 1);
+            if (data.contains(key))            text = text.replace(match.group(), data.get(key));
+            else if (key.equals("player"))     text = text.replace(match.group(), entity.getName());
+            else if (key.equals("target"))     text = text.replace(match.group(), entity.getName());
+            else if (key.equals("targetUUID")) text = text.replace(match.group(), entity.getUniqueId().toString());
+            match = pat.matcher(text);
+        }
+        return text;
     }
 
     /**
@@ -48,7 +76,7 @@ public class FlagTrigger implements Trigger<FlagApplyEvent> {
     // Adds flag duration as a usable Value
     @Override
     public void setValues(final FlagApplyEvent event, final CastData data) {
-        data.put("api-"+event.getFlag()+"-duration", event.getTicks());
+        data.put("api-" + event.getFlag() + "-duration", event.getTicks());
     }
 
     /**

--- a/src/main/java/studio/magemonkey/fabled/hook/DivinityHook.java
+++ b/src/main/java/studio/magemonkey/fabled/hook/DivinityHook.java
@@ -1,8 +1,14 @@
 package studio.magemonkey.fabled.hook;
 
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import studio.magemonkey.codex.util.DataUT;
+import studio.magemonkey.divinity.stats.EntityStats;
+import studio.magemonkey.divinity.stats.items.ItemStats;
+import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
+import studio.magemonkey.fabled.api.enums.Operation;
 
 public class DivinityHook {
     private static final NamespacedKey KEY_MODULE  = NamespacedKey.fromString("prorpgitems:qrpg_item_module");
@@ -15,4 +21,90 @@ public class DivinityHook {
         return data != null;
     }
 
+    /**
+     * Clamps a StatMechanic modifier amount so the resulting stat total does not exceed
+     * Divinity's configured cap for the given stat key.
+     * <p>
+     * Returns the original amount unchanged if the stat is unknown, has no cap (-1),
+     * or the operation is unrecognized.
+     * <p>
+     * NOTE: All Divinity class references are confined to this method body to allow
+     * lazy class-loading — this method must only be called when Divinity is confirmed active.
+     *
+     * @param key       Divinity stat key (e.g. "critical_rate")
+     * @param operation Fabled Operation (ADD_NUMBER or MULTIPLY_PERCENTAGE)
+     * @param amount    Modifier amount from the mechanic
+     * @param player    Target player
+     * @return clamped amount that will not push the stat past its Divinity cap
+     */
+    public static double clampStatAmount(String key, Operation operation, double amount, Player player) {
+        TypedStat.Type statType = TypedStat.Type.getByName(key);
+        if (statType == null) return amount;
+
+        TypedStat stat = ItemStats.getStat(statType);
+        if (stat == null) return amount;
+
+        double cap = stat.getCapability();
+        if (cap < 0) return amount; // unlimited cap
+
+        double currentValue = EntityStats.get(player).getItemStat(statType, true);
+
+        switch (operation) {
+            case ADD_NUMBER:
+                // Clamp: currentValue + amount <= cap  →  amount <= cap - currentValue
+                return Math.min(amount, Math.max(0, cap - currentValue));
+            case MULTIPLY_PERCENTAGE:
+                // New total = currentValue * amount; clamp: amount <= cap / currentValue
+                // Ensure we don't reduce the stat (amount >= 1.0)
+                if (currentValue <= 0) return amount;
+                if (currentValue >= cap) return 1.0; // already at/above cap, no-op multiplier
+                return Math.max(1.0, Math.min(amount, cap / currentValue));
+            default:
+                return amount;
+        }
+    }
+
+    /**
+     * Applies a temporary stat modifier to a non-player entity via Divinity's AdjustStatEffect.
+     * Returns the effect as Object to avoid eager class-loading of Divinity types in callers.
+     * Only call when Divinity is confirmed active.
+     *
+     * @param seconds negative value = permanent
+     * @return the created AdjustStatEffect, or null if stat key is unknown / operation invalid
+     */
+    public static Object applyStatToMob(LivingEntity target, LivingEntity caster,
+                                        String key, String operation, double amount, double seconds) {
+        studio.magemonkey.divinity.stats.items.api.ItemLoreStat<?> stat = ItemStats.getAttribute(key);
+        if (stat == null) return null;
+
+        java.util.function.DoubleUnaryOperator operator;
+        switch (operation) {
+            case "ADD_NUMBER":
+                operator = v -> v + amount;
+                break;
+            case "MULTIPLY_PERCENTAGE":
+                operator = v -> v * amount;
+                break;
+            default:
+                return null;
+        }
+
+        studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect effect =
+                new studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect.Builder(seconds)
+                        .withCaster(caster)
+                        .withAdjust(stat, operator)
+                        .build();
+        effect.applyTo(target);
+        return effect;
+    }
+
+    /**
+     * Removes a stat effect previously returned by {@link #applyStatToMob} from the target's EntityStats.
+     * Only call when Divinity is confirmed active.
+     */
+    public static void removeStatFromMob(LivingEntity target, Object effect) {
+        if (effect == null) return;
+        EntityStats.get(target).removeEffect(
+                (studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect) effect);
+    }
 }

--- a/src/main/java/studio/magemonkey/fabled/hook/PluginChecker.java
+++ b/src/main/java/studio/magemonkey/fabled/hook/PluginChecker.java
@@ -50,6 +50,7 @@ public class PluginChecker extends FabledListener {
     private static boolean parties;
     private static boolean mimic;
     private static boolean protocolLib;
+    private static boolean divinity;
 
     /**
      * Checks if vault permissions is active on the server
@@ -95,6 +96,8 @@ public class PluginChecker extends FabledListener {
 
     public static boolean isProtocolLibActive() {return protocolLib;}
 
+    public static boolean isDivinityActive() {return divinity;}
+
     public static boolean isPartiesActive() {
         return parties || Bukkit.getPluginManager()
                 .isPluginEnabled("FabledParties");
@@ -124,6 +127,7 @@ public class PluginChecker extends FabledListener {
         parties = pluginManager.isPluginEnabled("FabledParties");
         mimic = pluginManager.isPluginEnabled("Mimic");
         protocolLib = pluginManager.isPluginEnabled("ProtocolLib");
+        divinity = pluginManager.isPluginEnabled("Divinity");
     }
 
     @EventHandler
@@ -164,6 +168,9 @@ public class PluginChecker extends FabledListener {
                 break;
             case "ProtocolLib":
                 protocolLib = isEnabled;
+                break;
+            case "Divinity":
+                divinity = isEnabled;
                 break;
         }
     }

--- a/src/main/java/studio/magemonkey/fabled/manager/FabledAttribute.java
+++ b/src/main/java/studio/magemonkey/fabled/manager/FabledAttribute.java
@@ -20,7 +20,6 @@ import studio.magemonkey.fabled.log.LogType;
 import studio.magemonkey.fabled.log.Logger;
 
 import java.util.*;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -44,9 +43,9 @@ public class FabledAttribute implements IconHolder {
      */
     // Attribute description
     @Getter
-    private String   key;
-    private String   display;
-    private Supplier<ItemStack> iconFn;
+    private String    key;
+    private String    display;
+    private ItemStack icon;
     /**
      * -- GETTER --
      * Retrieves the max amount the attribute can be raised to
@@ -91,7 +90,7 @@ public class FabledAttribute implements IconHolder {
     public FabledAttribute(DataSection data, String key) {
         this.key = key.toLowerCase();
         this.display = data.getString(DISPLAY, key);
-        this.iconFn = () -> Data.parseIcon(data);
+        this.icon = Data.parseIcon(data);
         this.max = data.getInt(MAX, 999);
         // iomatix: base_cost and the modifier
         // e.g. per 0.3 increase -> 0.3=>0, 0.6=>0, 0.9=>0, 1.2=>1 (the first additional cost point) etc.
@@ -131,14 +130,23 @@ public class FabledAttribute implements IconHolder {
      */
     @Override
     public ItemStack getIcon(PlayerData data) {
-        ItemStack item     = iconFn.get();
+        ItemStack item     = new ItemStack(icon.getType());
+        ItemMeta  iconMeta = icon.getItemMeta();
         ItemMeta  meta     = item.getItemMeta();
-        if (meta != null) {
-            meta.setDisplayName(filter(data, meta.getDisplayName()));
-            List<String> iconLore = meta.getLore();
+        if (meta != null && iconMeta != null) {
+            meta.setDisplayName(filter(data, iconMeta.getDisplayName()));
+            List<String> iconLore = iconMeta.getLore();
             List<String> lore = iconLore != null
                     ? iconLore.stream().map(iconLine -> filter(data, iconLine)).collect(Collectors.toList())
                     : new ArrayList<>();
+
+            if (meta instanceof Damageable) {
+                ((Damageable) meta).setDamage(((Damageable) iconMeta).getDamage());
+            }
+
+            if (iconMeta.hasCustomModelData()) {
+                meta.setCustomModelData(iconMeta.getCustomModelData());
+            }
 
             meta.setLore(lore);
             item.setItemMeta(meta);
@@ -174,12 +182,22 @@ public class FabledAttribute implements IconHolder {
      * @return icon for the attribute for use in the GUI editor
      */
     public ItemStack getToolIcon() {
-        ItemStack icon     = this.iconFn.get();
+        ItemStack icon     = new ItemStack(this.icon.getType());
         ItemMeta  meta     = icon.getItemMeta();
-        if (meta == null) {
+        ItemMeta  iconMeta = this.icon.getItemMeta();
+        if (meta == null || iconMeta == null) {
             return icon;
         }
         meta.setDisplayName(key);
+        List<String> lore = iconMeta.hasLore()
+                ? iconMeta.getLore()
+                : null;
+        if (lore == null) {
+            lore = new ArrayList<>();
+        }
+        if (iconMeta.hasDisplayName())
+            lore.add(0, iconMeta.getDisplayName());
+        meta.setLore(lore);
         icon.setItemMeta(meta);
         return icon;
     }

--- a/src/main/java/studio/magemonkey/fabled/manager/RegistrationManager.java
+++ b/src/main/java/studio/magemonkey/fabled/manager/RegistrationManager.java
@@ -46,8 +46,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * <p>Skill API Registration Manager.</p>
@@ -63,7 +61,6 @@ public class RegistrationManager {
     private final        Fabled          api;
     private final        CommentedConfig skillConfig;
     private final        CommentedConfig classConfig;
-    private final        List<DeferredSave> deferredSaves = new ArrayList<>();
     private              Mode            mode         = Mode.STARTUP;
 
     /**
@@ -174,17 +171,21 @@ public class RegistrationManager {
                     continue;
                 }
                 try {
-                        DynamicSkill skill = new DynamicSkill(key);
-                        skill.load(skillConfig.getConfig().getSection(key));
-                        if (!Fabled.isSkillRegistered(skill.getName())) {
-                            api.addDynamicSkill(skill);
-                            skill.registerEvents(api);
-                            String path = getPath(Fabled.inst().getDataFolder() + File.separator + SKILL_DIR, key);
-                            if (path == null) path = key;
-                            queueDynamicSkillSave(skill, path, key);
-                            Logger.log(LogType.REGISTRATION, 2, "Loaded the dynamic skill: " + key);
-                        } else {
-                            Logger.invalid("Duplicate skill detected: " + key);
+                    DynamicSkill skill = new DynamicSkill(key);
+                    skill.load(skillConfig.getConfig().getSection(key));
+                    if (!Fabled.isSkillRegistered(skill.getName())) {
+                        api.addDynamicSkill(skill);
+                        skill.registerEvents(api);
+                        String path = getPath(Fabled.inst().getDataFolder() + File.separator + SKILL_DIR, key);
+                        if (path == null) path = key;
+                        CommentedConfig sConfig = new CommentedConfig(api, SKILL_DIR + path);
+                        sConfig.clear();
+                        skill.save(sConfig.getConfig().createSection(key));
+                        skill.save(skillConfig.getConfig().createSection(key));
+                        sConfig.save();
+                        Logger.log(LogType.REGISTRATION, 2, "Loaded the dynamic skill: " + key);
+                    } else {
+                        Logger.invalid("Duplicate skill detected: " + key);
                     }
                 } catch (Exception ex) {
                     Logger.invalid("Failed to load skill: " + key + " - " + ex.getMessage());
@@ -213,7 +214,10 @@ public class RegistrationManager {
                         if (!Fabled.isSkillRegistered(skill.getName())) {
                             api.addDynamicSkill(skill);
                             skill.registerEvents(api);
-                            queueDynamicSkillSave(skill, longName, name);
+                            sConfig.clear();
+                            skill.save(sConfig.getConfig().createSection(name));
+                            skill.save(skillConfig.getConfig().createSection(name));
+                            sConfig.save();
                             Logger.log(LogType.REGISTRATION, 2, "Loaded the dynamic skill: " + name);
                         } else if (Fabled.getSkill(name) instanceof DynamicSkill) {
                             Logger.log(LogType.REGISTRATION, 3, name + " is already loaded, skipping it");
@@ -259,16 +263,20 @@ public class RegistrationManager {
                     continue;
                 }
                 try {
-                        DynamicClass tree = new DynamicClass(api, key);
-                        tree.load(classConfig.getConfig().getSection(key));
-                        if (!Fabled.isClassRegistered(tree.getName())) {
-                            api.addDynamicClass(tree);
-                            String path = getPath(Fabled.inst().getDataFolder() + File.separator + CLASS_DIR, key);
-                            if (path == null) path = key;
-                            queueDynamicClassSave(tree, path, key);
-                            Logger.log(LogType.REGISTRATION, 2, "Loaded the dynamic class: " + key);
-                        } else {
-                            Logger.invalid("Duplicate class detected: " + key);
+                    DynamicClass tree = new DynamicClass(api, key);
+                    tree.load(classConfig.getConfig().getSection(key));
+                    if (!Fabled.isClassRegistered(tree.getName())) {
+                        api.addDynamicClass(tree);
+                        String path = getPath(Fabled.inst().getDataFolder() + File.separator + CLASS_DIR, key);
+                        if (path == null) path = key;
+                        CommentedConfig cConfig = new CommentedConfig(api, CLASS_DIR + path);
+                        cConfig.clear();
+                        tree.save(cConfig.getConfig().createSection(key));
+                        tree.save(classConfig.getConfig().createSection(key));
+                        cConfig.save();
+                        Logger.log(LogType.REGISTRATION, 2, "Loaded the dynamic class: " + key);
+                    } else {
+                        Logger.invalid("Duplicate class detected: " + key);
                     }
                 } catch (Exception ex) {
                     Logger.invalid("Failed to load class \"" + key + "\"");
@@ -296,7 +304,10 @@ public class RegistrationManager {
                         tree.load(section);
                         if (!Fabled.isClassRegistered(tree.getName())) {
                             api.addDynamicClass(tree);
-                            queueDynamicClassSave(tree, longName, name);
+                            cConfig.clear();
+                            tree.save(cConfig.getConfig().createSection(name));
+                            tree.save(classConfig.getConfig().createSection(name));
+                            cConfig.save();
                             Logger.log(LogType.REGISTRATION, 2, "Loaded the dynamic class: " + name);
                         } else if (Fabled.getClass(name) instanceof DynamicClass) {
                             Logger.log(LogType.REGISTRATION, 3, name + " is already loaded, skipping it");
@@ -327,68 +338,6 @@ public class RegistrationManager {
         Logger.log(LogType.REGISTRATION, 0, " - " + Fabled.getSkills().size() + " skills");
         Logger.log(LogType.REGISTRATION, 0, " - " + Fabled.getClasses().size() + " classes");
         Logger.log(LogType.REGISTRATION, 0, " Took " + (System.currentTimeMillis() - start) + "ms");
-        Bukkit.getScheduler().runTask(api, this::flushDeferredSaves);
-    }
-
-    private void queueDeferredSave(String description, Runnable saveTask) {
-        deferredSaves.add(new DeferredSave(description, saveTask));
-    }
-
-    private void flushDeferredSaves() {
-        if (deferredSaves.isEmpty()) return;
-
-        List<DeferredSave> savesToRun = new ArrayList<>(deferredSaves);
-        deferredSaves.clear();
-
-        for (DeferredSave deferredSave : savesToRun) {
-            try {
-                deferredSave.saveTask.run();
-            } catch (Exception ex) {
-                Logger.bug("Failed to save deferred " + deferredSave.description);
-                ex.printStackTrace();
-            }
-        }
-
-        skillConfig.save();
-        classConfig.save();
-    }
-
-    private void queueSkillFileSave(Skill skill) {
-        String skillName = skill.getName();
-        queueDeferredSave("skill \"" + skillName + "\"", () -> {
-            CommentedConfig singleFile = new CommentedConfig(api, "skill" + File.separator + skillName);
-            skill.save(singleFile.getConfig());
-            singleFile.save();
-        });
-    }
-
-    private void queueClassFileSave(FabledClass fabledClass) {
-        String className = fabledClass.getName();
-        queueDeferredSave("class \"" + className + "\"", () -> {
-            CommentedConfig singleFile = new CommentedConfig(api, "class" + File.separator + className);
-            fabledClass.save(singleFile.getConfig());
-            singleFile.save();
-        });
-    }
-
-    private void queueDynamicSkillSave(DynamicSkill skill, String path, String key) {
-        queueDeferredSave("dynamic skill \"" + key + "\"", () -> {
-            CommentedConfig singleFile = new CommentedConfig(api, SKILL_DIR + path);
-            singleFile.clear();
-            skill.save(singleFile.getConfig().createSection(key));
-            skill.save(skillConfig.getConfig().createSection(key));
-            singleFile.save();
-        });
-    }
-
-    private void queueDynamicClassSave(DynamicClass tree, String path, String key) {
-        queueDeferredSave("dynamic class \"" + key + "\"", () -> {
-            CommentedConfig singleFile = new CommentedConfig(api, CLASS_DIR + path);
-            singleFile.clear();
-            tree.save(singleFile.getConfig().createSection(key));
-            tree.save(classConfig.getConfig().createSection(key));
-            singleFile.save();
-        });
     }
 
     private String getQualifiedFileName(Path root, Path path) {
@@ -456,10 +405,15 @@ public class RegistrationManager {
             DataSection     config     = singleFile.getConfig();
 
             try {
-                if (!config.keys().isEmpty()) {
-                    skill.load(config);
-                }
-                queueSkillFileSave(skill);
+                // Soft save to ensure optional data starts off in the config
+                skill.softSave(config);
+
+                // Load the config data to apply any previous data
+                skill.load(config);
+
+                // Finally, do a full save to make sure the config is up to date
+                skill.save(config);
+                singleFile.save();
 
                 if (skill instanceof Listener) {
                     Bukkit.getServer().getPluginManager().registerEvents((Listener) skill, api);
@@ -509,10 +463,16 @@ public class RegistrationManager {
             DataSection     config     = singleFile.getConfig();
 
             try {
-                if (!config.keys().isEmpty()) {
-                    fabledClass.load(config);
-                }
-                queueClassFileSave(fabledClass);
+
+                // Soft save to ensure optional data starts off in the config
+                fabledClass.softSave(config);
+
+                // Load the config data to apply any previous data
+                fabledClass.load(config);
+
+                // Finally, do a full save to make sure the config is up to date
+                fabledClass.save(config);
+                singleFile.save();
 
                 // Skill is ready to be registered
                 return fabledClass;
@@ -543,15 +503,5 @@ public class RegistrationManager {
         CLASS,
         DYNAMIC,
         DONE
-    }
-
-    private static class DeferredSave {
-        private final String   description;
-        private final Runnable saveTask;
-
-        private DeferredSave(String description, Runnable saveTask) {
-            this.description = description;
-            this.saveTask = saveTask;
-        }
     }
 }


### PR DESCRIPTION
Coped from copilot:

### 1. **ItemStack Refactoring** (FabledClass, Skill, FabledAttribute, Data.java)
- Replaced `Supplier<ItemStack>` lazy loading with direct `ItemStack` fields
- Updated icon handling to maintain display name/lore/damage/custom model data during GUI operations
- Simplified `Data.parseIcon()` / `serializeIcon()` by removing Codex item type lookups

### 2. **Divinity Plugin Integration** (DivinityHook.java, StatMechanic, HealMechanic, StatusMechanic, DurabilityMechanic)
- New `DivinityHook` methods: `clampStatAmount()`, `applyStatToMob()`, `removeStatFromMob()`
- `StatMechanic` now respects Divinity's stat caps via clamping
- `HealMechanic` applies Divinity's healing-cast and healing-received multipliers
- `StatusMechanic` applies CC duration multiplier and CC resistance reduction
- `DurabilityMechanic` integrates with Divinity's durability system
- Added `PluginChecker.isDivinityActive()` tracking

### 3. **Bow/Crossbow Attack Indicator Condition** (AttackIndicatorCondition.java)
- New `ShootListener` captures bow/crossbow draw force via `EntityShootBowEvent` metadata
- Supports "auto", "bow", and "crossbow" weapon modes
- Handles both pre-launch polling (draw state) and post-launch metadata snapshots
- Includes reflection fallbacks for Paper API methods on Spigot

### 4. **Flag System & Reentrance Protection** (FlagManager.java, FlagTrigger.java, FlagExpireTrigger.java)
- `FlagManager` guards against reentrant `clearFlags()` calls with `clearingEntities` set
- `FlagTrigger` and `FlagExpireTrigger` now resolve dynamic placeholders (`{player}`, `{target}`, `{targetUUID}`, custom cast data)
- Fixes infinite recursion when `FlagExpireTrigger` skills add flags during clearing

### 5. **Other Mechanics & Conditions Fixes**
- `FlagCondition`: Apply `filter()` to flag names for dynamic variable resolution
- `FlagMechanic`, `FlagToggleMechanic`, `FlagClearMechanic`: Apply `filter()` to flag keys
- `DamageMechanic`: Added damage flags metadata (crit ignore, dodge ignore, block ignore, bleed/vamp disable, skill crit ignore)
- `RepeatMechanic`: New `single-instance` setting to cancel previous repeats before starting new ones
- `TargetComponent`: Allow self-targeting when `IncludeCaster` is not `FALSE`
- `Skill.damage()`: Wrapped damage application in try-finally for proper skill damage flag cleanup

### 6. **Config Save Refactoring** (RegistrationManager.java)
- Removed deferred save queue and async batch saves
- Now saves dynamic skills/classes immediately during initialization
- Each file receives: soft-save → load → full save to ensure optional fields are populated

### 7. **New Event** (PlayerMaxManaChangeEvent.java)
- Fired after player mana calculation with attribute/class bonuses
- Allows plugins to apply additional mana bonuses
- Clamped to minimum 0

### 8. **UI & Display Improvements**
- `FabledAttribute.getToolIcon()`: Now preserves icon metadata (lore, display name)
- `Skill.getIndicator()`: Fixed to preserve item metadata including damage and custom model data