### PR TITLE
Fix multi-select dropdowns freezing the editor and latest-version detection

### DIFF
--- a/src/api/components/components.svelte.ts
+++ b/src/api/components/components.svelte.ts
@@ -174,7 +174,7 @@ class ConsumeTrigger extends FabledTrigger {
 			name:         'Consume',
 			description:  'Applies skill effects when a player consumes an item',
 			data:         [
-				...itemConditionOptions(new DropdownSelect('Material', 'material', getAnyConsumable, 'Any', true)
+				...itemConditionOptions(new DropdownSelect('Material', 'material', getAnyConsumable, ['Any'], true)
 					.setTooltip('The type of item that the player has consumed.')
 					.requireValue('check-mat', [true]))
 			],
@@ -530,7 +530,7 @@ class LaunchTrigger extends FabledTrigger {
 		super({
 			name:         'Launch',
 			description:  'Applies skill effects when a player launches a projectile',
-			data:         [new DropdownSelect('Types', 'types', getAnyProjectiles, 'Any', true)
+			data:         [new DropdownSelect('Types', 'types', getAnyProjectiles, ['Any'], true)
 				.setTooltip('The type of projectile that should be launched')],
 			summaryItems: ['types']
 		});

--- a/src/api/options/classselect.svelte.ts
+++ b/src/api/options/classselect.svelte.ts
@@ -17,6 +17,7 @@ export default class ClassSelect extends Requirements implements ComponentOption
 		this.name     = name;
 		this.key      = key;
 		this.multiple = multiple;
+		this.data     = multiple ? [] : '';
 	}
 
 	setTooltip = (tooltip: string): this => {
@@ -25,8 +26,8 @@ export default class ClassSelect extends Requirements implements ComponentOption
 	};
 
 	clone = (): ComponentOption => {
-		const select = new ClassSelect(this.name, this.key);
-		select.data  = this.data;
+		const select = new ClassSelect(this.name, this.key, this.multiple);
+		select.data  = this.data instanceof Array ? [...this.data] : this.data;
 		return select;
 	};
 
@@ -52,5 +53,11 @@ export default class ClassSelect extends Requirements implements ComponentOption
 		}
 	};
 
-	deserialize = (yaml: Unknown) => this.data = <string | string[]>yaml[this.key] || (this.multiple ? [] : '');
+	deserialize = (yaml: Unknown) => {
+		const val = <string | string[]>yaml[this.key];
+		// Coerce the stored value to match the select mode, as a scalar on a
+		// multi-select (or a list on a single select) breaks the dropdown
+		if (this.multiple) this.data = !val ? [] : val instanceof Array ? val : [val];
+		else this.data = (val instanceof Array ? val[0] : val) || '';
+	};
 }

--- a/src/api/options/dropdownselect.svelte.ts
+++ b/src/api/options/dropdownselect.svelte.ts
@@ -27,13 +27,25 @@ export default class DropdownSelect extends Requirements implements ComponentOpt
 		if (typeof items === 'function') this.dataSource = items;
 		else this.data.value = items;
 		if (multiple) this.data.selected = [];
-		if (def) this.data.selected = def;
+		if (def) {
+			// Normalize the default so it always matches the select mode,
+			// as a scalar default on a multi-select breaks filtering/removal
+			if (multiple && !(def instanceof Array)) this.data.selected = [def];
+			else if (!multiple && def instanceof Array) this.data.selected = def[0];
+			else this.data.selected = def;
+		}
 
 		this.data.multiple = multiple;
 	}
 
 	public init = () => {
-		if (this.dataSource) this.data.value = this.dataSource();
+		if (this.dataSource) {
+			const value = this.dataSource();
+			// Only write when the contents actually changed. init() runs inside an
+			// effect that also reads this state, so an unconditional write loops forever
+			if (value.length !== this.data.value.length || value.some((item, i) => item !== this.data.value[i]))
+				this.data.value = value;
+		}
 
 		if (!this.data.selected && this.data.value.length > 0 && !this.data.multiple)
 			this.data.selected = this.data.value[0];

--- a/src/api/options/skillselect.svelte.ts
+++ b/src/api/options/skillselect.svelte.ts
@@ -16,6 +16,7 @@ export default class SkillSelect extends Requirements implements ComponentOption
 		this.name     = name;
 		this.key      = key;
 		this.multiple = multiple;
+		this.data     = multiple ? [] : '';
 	}
 
 	setTooltip = (tooltip: string): this => {
@@ -24,8 +25,8 @@ export default class SkillSelect extends Requirements implements ComponentOption
 	};
 
 	clone = (): ComponentOption => {
-		const select = new SkillSelect(this.name, this.key);
-		select.data  = this.data;
+		const select = new SkillSelect(this.name, this.key, this.multiple);
+		select.data  = this.data instanceof Array ? [...this.data] : this.data;
 		return select;
 	};
 
@@ -50,11 +51,16 @@ export default class SkillSelect extends Requirements implements ComponentOption
 		const skillName = <string | string[]>yaml[this.key];
 
 		// Let's attempt to get the skill from the skill store before creating a dummy skill for display
-		if (skillName instanceof Array) {
-			this.data = skillName.map(skill => skillStore.getSkill(skill) || new FabledSkill({ name: skill }));
-		} else if (skillName)
-			this.data = skillStore.getSkill(skillName) || new FabledSkill({ name: skillName });
-		else
-			this.data = this.multiple ? [] : '';
+		const lookup = (skill: string) => skillStore.getSkill(skill) || new FabledSkill({ name: skill });
+
+		// Coerce the stored value to match the select mode, as a scalar on a
+		// multi-select (or a list on a single select) breaks the dropdown
+		if (this.multiple) {
+			const names = !skillName ? [] : skillName instanceof Array ? skillName : [skillName];
+			this.data   = names.map(lookup);
+		} else {
+			const name = skillName instanceof Array ? skillName[0] : skillName;
+			this.data  = name ? lookup(name) : '';
+		}
 	};
 }

--- a/src/components/input/SearchableSelect.svelte
+++ b/src/components/input/SearchableSelect.svelte
@@ -111,7 +111,7 @@
 		const cancelled = onremove?.(<never>item) || true;
 		if (!cancelled) return;
 
-		if (multiple) selected = (<Array<unknown>>selected).filter((s: unknown) => s != item);
+		if (multiple && selected instanceof Array) selected = selected.filter((s: unknown) => s != item);
 		else selected = undefined;
 	};
 

--- a/src/version/data.ts
+++ b/src/version/data.ts
@@ -25,13 +25,21 @@ export const VERSIONS                           = {
 	'17':    DATA_1_17,
 	'16':    DATA_1_16
 };
-export const versionData: Writable<VersionData> = writable(VERSIONS[<Versions>Object.keys(VERSIONS)[Object.keys(VERSIONS).length - 1]]);
+// Object.keys() lists integer-like keys ('21', '16', ...) before keys with dots,
+// so sort numerically instead of relying on insertion order to find the latest version
+const compareVersions = (a: string, b: string) => {
+	const [aMajor, aMinor = 0] = a.split('.').map(Number);
+	const [bMajor, bMinor = 0] = b.split('.').map(Number);
+	return aMajor - bMajor || aMinor - bMinor;
+};
+const LATEST_VERSION = <Versions>Object.keys(VERSIONS).sort(compareVersions).pop();
 
-export const version: Writable<Versions> = localStore<Versions>('server-version', <Versions>Object.keys(VERSIONS)[Object.keys(VERSIONS).length - 1]);
+export const versionData: Writable<VersionData> = writable(VERSIONS[LATEST_VERSION]);
+
+export const version: Writable<Versions> = localStore<Versions>('server-version', LATEST_VERSION);
 version.subscribe((ver: Versions) => {
 	if (!(ver in VERSIONS)) {
-		ver = <Versions>Object.keys(VERSIONS)[0];
-		version.set(ver);
+		version.set(LATEST_VERSION);
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Fixes the Projectile Launch trigger's Types dropdown rendering no options and freezing the page when the auto-filled `Any` value is cleared, plus related latent bugs found while auditing every other select option.

### Root cause

#1278 converted the Launch and Consume trigger dropdowns to multi-selects but kept their scalar `'Any'` defaults. With a non-array selection in multi-select mode:

- `SearchableSelect` filters out every option, so the dropdown renders empty.
- Removing the auto-filled chip throws `selected.filter is not a function`, and once the selection ends up empty, `DropdownSelect.init()` — which runs inside `ComponentModal`'s `$effect.pre` — rewrites its own tracked state on every pass, looping until `effect_update_depth_exceeded` and locking up the page.

This reproduces on any server version, not just 1.21.11.

### Changes

**Dropdown fixes**
- Use array defaults (`['Any']`) for the Launch trigger Types and Consume trigger Material dropdowns.
- `DropdownSelect` constructor now normalizes the default to match the select mode, protecting all other call sites.
- `DropdownSelect.init()` only rewrites the option list when its contents actually changed, breaking the effect loop.
- `SearchableSelect.remove()` guards against non-array selections.

**Same mismatch in ClassSelect / SkillSelect** (Class condition, Skill Level condition, Skill Cast trigger)
- Deserializing a scalar YAML value (e.g. `class: Warrior`) in multi-select mode produced the same broken state; values are now coerced to match the select mode.
- `data` initializes as `''`/`[]` per mode instead of always `[]`.
- `clone()` no longer drops the `multiple` flag, which silently turned copied single-selects into multi-selects.

**Latest-version detection** (`src/version/data.ts`)
- `Object.keys()` lists integer-like keys (`'21'`, `'16'`) before dotted keys (`'21.11'`), so indexing the last key made `20.4` the default server version for new users, and the invalid-version fallback resolved to `16`. Version keys are now compared numerically (major, then minor), and both the default and the fallback use the real latest version.

## Testing

- Vitest suite passes (23/23).
- Verified end-to-end with Playwright against the dev server:
  - Before: 0 options rendered in the Launch Types dropdown; clearing `Any` threw and hit `effect_update_depth_exceeded`.
  - After: all 19 projectile types populate on 1.21.11, selecting adds chips, chip-click and backspace removal both work with no console errors and the page stays responsive.
  - Fresh profile now defaults to server version `21.11`; an invalid stored version also falls back to `21.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014C3JECMmFRXaQNQneUtzdt

---
_Generated by [Claude Code](https://claude.ai/code/session_014C3JECMmFRXaQNQneUtzdt)_