### PR TITLE
feat: integrate with Divinity plugin stats, healing, CC, and durability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,12 @@
             <artifactId>codex</artifactId>
             <version>${codex.version}</version>
         </dependency>
+        <dependency>
+            <groupId>studio.magemonkey</groupId>
+            <artifactId>divinity</artifactId>
+            <version>1.0.2-R0.57-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>com.mojang</groupId>

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DamageMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DamageMechanic.java
@@ -28,6 +28,8 @@ package studio.magemonkey.fabled.dynamic.mechanic;
 
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import studio.magemonkey.fabled.Fabled;
 
 import java.util.List;
 import java.util.Locale;
@@ -44,6 +46,14 @@ public class DamageMechanic extends MechanicComponent {
     private static final String IGNORE_DIVINITY = "ignore-divinity";
     private static final String CAUSE           = "cause";
     private static final String NO_SHAKE        = "no-shake";
+    private static final String IGNORE_CRIT     = "divinity-ignore-crit";
+    private static final String IGNORE_DODGE    = "divinity-ignore-dodge";
+    private static final String IGNORE_BLOCK    = "divinity-ignore-block";
+    private static final String NO_BLEED        = "divinity-no-bleed";
+    private static final String NO_VAMP         = "divinity-no-vamp";
+    private static final String IGNORE_SKILL_CRIT  = "ignore-skill-crit";
+
+    static final String DMG_FLAGS_META = "fabled_dmg_flags";
 
     @Override
     public String getKey() {
@@ -65,34 +75,51 @@ public class DamageMechanic extends MechanicComponent {
         if (damage < 0) {
             return false;
         }
-        for (LivingEntity target : targets) {
-            if (target.isDead()) {
-                continue;
-            }
 
-            double amount = damage;
-            if (percent) {
-                amount = damage * target.getMaxHealth() / 100;
-            } else if (missing) {
-                amount = damage * (target.getMaxHealth() - target.getHealth()) / 100;
-            } else if (left) {
-                amount = damage * target.getHealth() / 100;
+        int dmgFlags = 0;
+        if (settings.getBool(IGNORE_CRIT,  false)) dmgFlags |= 0x01;
+        if (settings.getBool(IGNORE_DODGE, false)) dmgFlags |= 0x02;
+        if (settings.getBool(IGNORE_BLOCK, false)) dmgFlags |= 0x04;
+        if (settings.getBool(NO_BLEED,     false)) dmgFlags |= 0x08;
+        if (settings.getBool(NO_VAMP,      false)) dmgFlags |= 0x10;
+        if (settings.getBool(IGNORE_SKILL_CRIT, false)) dmgFlags |= 0x20;
+        if (dmgFlags != 0)
+            caster.setMetadata(DMG_FLAGS_META, new FixedMetadataValue(Fabled.inst(), dmgFlags));
+
+        try {
+            for (LivingEntity target : targets) {
+                if (target.isDead()) {
+                    continue;
+                }
+
+                double amount = damage;
+                if (percent) {
+                    amount = damage * target.getMaxHealth() / 100;
+                } else if (missing) {
+                    amount = damage * (target.getMaxHealth() - target.getHealth()) / 100;
+                } else if (left) {
+                    amount = damage * target.getHealth() / 100;
+                }
+                if (trueDmg) {
+                    skill.trueDamage(target, amount, caster);
+                } else {
+                    skill.damage(target,
+                            amount,
+                            caster,
+                            classification,
+                            knockback,
+                            ignoreDivinity,
+                            EntityDamageEvent.DamageCause.valueOf(settings.getString(CAUSE, "Entity Attack")
+                                    .toUpperCase(Locale.US)
+                                    .replace(' ', '_')),
+                            noShake);
+                }
             }
-            if (trueDmg) {
-                skill.trueDamage(target, amount, caster);
-            } else {
-                skill.damage(target,
-                        amount,
-                        caster,
-                        classification,
-                        knockback,
-                        ignoreDivinity,
-                        EntityDamageEvent.DamageCause.valueOf(settings.getString(CAUSE, "Entity Attack")
-                                .toUpperCase(Locale.US)
-                                .replace(' ', '_')),
-                        noShake);
-            }
+        } finally {
+            if (dmgFlags != 0)
+                caster.removeMetadata(DMG_FLAGS_META, Fabled.inst());
         }
+
         return !targets.isEmpty();
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DurabilityMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DurabilityMechanic.java
@@ -9,6 +9,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import studio.magemonkey.divinity.stats.items.ItemStats;
 import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 import studio.magemonkey.divinity.stats.items.attributes.stats.DurabilityStat;
+import studio.magemonkey.fabled.hook.PluginChecker;
 
 import java.util.List;
 
@@ -63,12 +64,14 @@ public class DurabilityMechanic extends MechanicComponent {
         im.setDamage(im.getDamage() + amount);
         item.setItemMeta(im);
 
-        try {
-            DurabilityStat duraStat = (DurabilityStat) ItemStats.getStat(TypedStat.Type.DURABILITY);
-            if (duraStat != null && ItemStats.hasStat(item, player, TypedStat.Type.DURABILITY)) {
-                duraStat.reduceDurability(player, item, amount);
-            }
-        } catch (Exception ignored) { /* Divinity not loaded */ }
+        if (PluginChecker.isDivinityActive()) {
+            try {
+                DurabilityStat duraStat = (DurabilityStat) ItemStats.getStat(TypedStat.Type.DURABILITY);
+                if (duraStat != null && ItemStats.hasStat(item, player, TypedStat.Type.DURABILITY)) {
+                    duraStat.reduceDurability(player, item, amount);
+                }
+            } catch (Throwable ignored) { /* Divinity present but incompatible/misbehaving */ }
+        }
 
         return true;
     }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DurabilityMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/DurabilityMechanic.java
@@ -6,6 +6,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
+import studio.magemonkey.divinity.stats.items.ItemStats;
+import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
+import studio.magemonkey.divinity.stats.items.attributes.stats.DurabilityStat;
 
 import java.util.List;
 
@@ -59,6 +62,14 @@ public class DurabilityMechanic extends MechanicComponent {
         }
         im.setDamage(im.getDamage() + amount);
         item.setItemMeta(im);
+
+        try {
+            DurabilityStat duraStat = (DurabilityStat) ItemStats.getStat(TypedStat.Type.DURABILITY);
+            if (duraStat != null && ItemStats.hasStat(item, player, TypedStat.Type.DURABILITY)) {
+                duraStat.reduceDurability(player, item, amount);
+            }
+        } catch (Exception ignored) { /* Divinity not loaded */ }
+
         return true;
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/HealMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/HealMechanic.java
@@ -31,6 +31,7 @@ import org.bukkit.entity.LivingEntity;
 import studio.magemonkey.divinity.stats.EntityStats;
 import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 import studio.magemonkey.fabled.api.event.SkillHealEvent;
+import studio.magemonkey.fabled.hook.PluginChecker;
 
 import java.util.List;
 
@@ -67,18 +68,18 @@ public class HealMechanic extends MechanicComponent {
                 amount = target.getMaxHealth() * value / 100;
             }
 
-            if (!ignoreHealingCast) {
+            if (!ignoreHealingCast && PluginChecker.isDivinityActive()) {
                 try {
                     double healCast = EntityStats.get(caster).getItemStat(TypedStat.Type.HEALING_CAST, false);
                     if (healCast != 0) amount *= (1.0 + healCast / 100.0);
-                } catch (Exception ignored) { /* Divinity not loaded */ }
+                } catch (Throwable ignored) { /* Divinity present but incompatible/misbehaving */ }
             }
 
-            if (!ignoreHealingReceived) {
+            if (!ignoreHealingReceived && PluginChecker.isDivinityActive()) {
                 try {
                     double healReceived = EntityStats.get(target).getItemStat(TypedStat.Type.HEALING_RECEIVED, false);
                     if (healReceived != 0) amount *= (1.0 + healReceived / 100.0);
-                } catch (Exception ignored) { /* Divinity not loaded */ }
+                } catch (Throwable ignored) { /* Divinity present but incompatible/misbehaving */ }
             }
 
             SkillHealEvent event = new SkillHealEvent(caster, target, amount);

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/HealMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/HealMechanic.java
@@ -28,6 +28,8 @@ package studio.magemonkey.fabled.dynamic.mechanic;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
+import studio.magemonkey.divinity.stats.EntityStats;
+import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 import studio.magemonkey.fabled.api.event.SkillHealEvent;
 
 import java.util.List;
@@ -36,8 +38,10 @@ import java.util.List;
  * Heals each target
  */
 public class HealMechanic extends MechanicComponent {
-    private static final String TYPE  = "type";
-    private static final String VALUE = "value";
+    private static final String TYPE                    = "type";
+    private static final String VALUE                   = "value";
+    private static final String IGNORE_HEALING_CAST     = "ignore-healing-cast";
+    private static final String IGNORE_HEALING_RECEIVED = "ignore-healing-received";
 
     @Override
     public String getKey() {
@@ -46,8 +50,10 @@ public class HealMechanic extends MechanicComponent {
 
     @Override
     public boolean execute(LivingEntity caster, int level, List<LivingEntity> targets, boolean force) {
-        boolean percent = settings.getString(TYPE, "health").toLowerCase().equals("percent");
-        double  value   = parseValues(caster, VALUE, level, 1.0);
+        boolean percent              = settings.getString(TYPE, "health").toLowerCase().equals("percent");
+        double  value                = parseValues(caster, VALUE, level, 1.0);
+        boolean ignoreHealingCast    = settings.getBool(IGNORE_HEALING_CAST, false);
+        boolean ignoreHealingReceived = settings.getBool(IGNORE_HEALING_RECEIVED, false);
         if (value < 0) {
             return false;
         }
@@ -59,6 +65,20 @@ public class HealMechanic extends MechanicComponent {
             double amount = value;
             if (percent) {
                 amount = target.getMaxHealth() * value / 100;
+            }
+
+            if (!ignoreHealingCast) {
+                try {
+                    double healCast = EntityStats.get(caster).getItemStat(TypedStat.Type.HEALING_CAST, false);
+                    if (healCast != 0) amount *= (1.0 + healCast / 100.0);
+                } catch (Exception ignored) { /* Divinity not loaded */ }
+            }
+
+            if (!ignoreHealingReceived) {
+                try {
+                    double healReceived = EntityStats.get(target).getItemStat(TypedStat.Type.HEALING_RECEIVED, false);
+                    if (healReceived != 0) amount *= (1.0 + healReceived / 100.0);
+                } catch (Exception ignored) { /* Divinity not loaded */ }
             }
 
             SkillHealEvent event = new SkillHealEvent(caster, target, amount);

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatMechanic.java
@@ -35,6 +35,8 @@ import studio.magemonkey.fabled.Fabled;
 import studio.magemonkey.fabled.api.enums.Operation;
 import studio.magemonkey.fabled.api.player.PlayerData;
 import studio.magemonkey.fabled.api.player.PlayerStatModifier;
+import studio.magemonkey.fabled.hook.DivinityHook;
+import studio.magemonkey.fabled.hook.PluginChecker;
 
 import java.util.HashMap;
 import java.util.List;
@@ -44,13 +46,15 @@ import java.util.Map;
  * Applies a flag to each target
  */
 public class StatMechanic extends MechanicComponent {
-    private static final String KEY       = "key";
-    private static final String OPERATION = "operation";
-    private static final String AMOUNT    = "amount";
-    private static final String SECONDS   = "seconds";
-    private static final String STACKABLE = "stackable";
+    private static final String KEY               = "key";
+    private static final String OPERATION         = "operation";
+    private static final String AMOUNT            = "amount";
+    private static final String SECONDS           = "seconds";
+    private static final String STACKABLE         = "stackable";
+    private static final String IGNORE_DIVINITY_CAP = "ignore-divinity-cap";
 
-    private final Map<Integer, Map<String, StatTask>> tasks = new HashMap<>();
+    private final Map<Integer, Map<String, StatTask>> tasks      = new HashMap<>();
+    private final Map<Integer, Map<Integer, Object>>  mobEffects = new HashMap<>();
 
     @Override
     public String getKey() {
@@ -63,6 +67,7 @@ public class StatMechanic extends MechanicComponent {
         if (casterTasks != null) {
             casterTasks.values().forEach(StatTask::stop);
         }
+        mobEffects.remove(user.getEntityId());
     }
 
     @Override
@@ -78,13 +83,25 @@ public class StatMechanic extends MechanicComponent {
         final boolean               stackable   = settings.getBool(STACKABLE, false);
         final int                   ticks       = (int) (seconds * 20);
         final String                operation   = settings.getString(OPERATION, "MULTIPLY_PERCENTAGE");
+        final boolean               ignoreCap   = settings.getBool(IGNORE_DIVINITY_CAP, false);
 
         boolean worked = false;
         for (LivingEntity target : targets) {
             if (target instanceof Player) {
                 worked = true;
                 final PlayerData data = Fabled.getData((Player) target);
-                PlayerStatModifier modifier = new PlayerStatModifier("fabled.mechanic.stat_mechanic", amount,
+
+                double effectiveAmount = amount;
+                if (!ignoreCap && PluginChecker.isDivinityActive()) {
+                    try {
+                        effectiveAmount = DivinityHook.clampStatAmount(
+                                key, Operation.valueOf(operation), amount, (Player) target);
+                    } catch (Exception ignored) {
+                        // safe fallback: use original amount
+                    }
+                }
+
+                PlayerStatModifier modifier = new PlayerStatModifier("fabled.mechanic.stat_mechanic", effectiveAmount,
                         Operation.valueOf(operation), false);
 
                 if (casterTasks.containsKey(data.getPlayerName()) && !stackable) {
@@ -94,7 +111,7 @@ public class StatMechanic extends MechanicComponent {
 
                     data.addStatModifier(key, modifier, true);
 
-                    old.cancel();
+                    old.stop(); // use stop() instead of cancel() — cancel() throws ISE when seconds:-1 (task never scheduled)
                 } else {
                     data.addStatModifier(key, modifier, true);
                 }
@@ -103,6 +120,29 @@ public class StatMechanic extends MechanicComponent {
                 casterTasks.put(data.getPlayerName(), task);
                 if (ticks >= 0) {
                     Fabled.schedule(task, ticks);
+                }
+            } else if (PluginChecker.isDivinityActive()) {
+                Object effect = DivinityHook.applyStatToMob(target, caster, key, operation, amount, seconds);
+                if (effect == null) continue;
+
+                worked = true;
+                final Map<Integer, Object> casterMobEffects =
+                        mobEffects.computeIfAbsent(caster.getEntityId(), HashMap::new);
+                final int targetId = target.getEntityId();
+
+                if (casterMobEffects.containsKey(targetId) && !stackable) {
+                    DivinityHook.removeStatFromMob(target, casterMobEffects.remove(targetId));
+                }
+
+                casterMobEffects.put(targetId, effect);
+
+                if (ticks >= 0) {
+                    Fabled.schedule(new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            casterMobEffects.remove(targetId);
+                        }
+                    }, ticks);
                 }
             }
         }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatusMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatusMechanic.java
@@ -27,6 +27,8 @@
 package studio.magemonkey.fabled.dynamic.mechanic;
 
 import org.bukkit.entity.LivingEntity;
+import studio.magemonkey.divinity.stats.EntityStats;
+import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 import studio.magemonkey.fabled.api.util.FlagManager;
 
 import java.util.List;
@@ -35,8 +37,10 @@ import java.util.List;
  * Applies a flag to each target
  */
 public class StatusMechanic extends MechanicComponent {
-    private static final String KEY      = "status";
-    private static final String DURATION = "duration";
+    private static final String KEY              = "status";
+    private static final String DURATION         = "duration";
+    private static final String IGNORE_CC_RES    = "ignore-cc-resistance";
+    private static final String IGNORE_CC_DUR    = "ignore-cc-duration";
 
     @Override
     public String getKey() {
@@ -49,10 +53,32 @@ public class StatusMechanic extends MechanicComponent {
             return false;
         }
 
-        String key     = settings.getString(KEY, "stun").toLowerCase();
-        double seconds = parseValues(caster, DURATION, level, 3.0);
-        int    ticks   = (int) (seconds * 20);
+        String  key           = settings.getString(KEY, "stun").toLowerCase();
+        double  seconds       = parseValues(caster, DURATION, level, 3.0);
+        boolean ignoreCCRes   = settings.getBool(IGNORE_CC_RES, false);
+        boolean ignoreCCDur   = settings.getBool(IGNORE_CC_DUR, false);
+        int baseTicks = (int) (seconds * 20);
+        if (!ignoreCCDur) {
+            try {
+                EntityStats casterStats = EntityStats.get(caster);
+                double      ccDuration  = casterStats.getItemStat(TypedStat.Type.CC_DURATION, false);
+                if (ccDuration != 0) {
+                    baseTicks = (int) (baseTicks * (1.0 + ccDuration / 100.0));
+                }
+            } catch (Exception ignored) { /* Divinity not loaded */ }
+        }
+
         for (LivingEntity target : targets) {
+            int ticks = baseTicks;
+            if (!ignoreCCRes) {
+                try {
+                    EntityStats stats      = EntityStats.get(target);
+                    double      resistance = stats.getItemStat(TypedStat.Type.CC_RESISTANCE, false);
+                    if (resistance > 0) {
+                        ticks = (int) (ticks * (1.0 - resistance / 100.0));
+                    }
+                } catch (Exception ignored) { /* Divinity not loaded */ }
+            }
             FlagManager.addFlag(target, key, ticks);
         }
         return !targets.isEmpty();

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatusMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/StatusMechanic.java
@@ -30,6 +30,7 @@ import org.bukkit.entity.LivingEntity;
 import studio.magemonkey.divinity.stats.EntityStats;
 import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 import studio.magemonkey.fabled.api.util.FlagManager;
+import studio.magemonkey.fabled.hook.PluginChecker;
 
 import java.util.List;
 
@@ -58,26 +59,26 @@ public class StatusMechanic extends MechanicComponent {
         boolean ignoreCCRes   = settings.getBool(IGNORE_CC_RES, false);
         boolean ignoreCCDur   = settings.getBool(IGNORE_CC_DUR, false);
         int baseTicks = (int) (seconds * 20);
-        if (!ignoreCCDur) {
+        if (!ignoreCCDur && PluginChecker.isDivinityActive()) {
             try {
                 EntityStats casterStats = EntityStats.get(caster);
                 double      ccDuration  = casterStats.getItemStat(TypedStat.Type.CC_DURATION, false);
                 if (ccDuration != 0) {
                     baseTicks = (int) (baseTicks * (1.0 + ccDuration / 100.0));
                 }
-            } catch (Exception ignored) { /* Divinity not loaded */ }
+            } catch (Throwable ignored) { /* Divinity present but incompatible/misbehaving */ }
         }
 
         for (LivingEntity target : targets) {
             int ticks = baseTicks;
-            if (!ignoreCCRes) {
+            if (!ignoreCCRes && PluginChecker.isDivinityActive()) {
                 try {
                     EntityStats stats      = EntityStats.get(target);
                     double      resistance = stats.getItemStat(TypedStat.Type.CC_RESISTANCE, false);
                     if (resistance > 0) {
                         ticks = (int) (ticks * (1.0 - resistance / 100.0));
                     }
-                } catch (Exception ignored) { /* Divinity not loaded */ }
+                } catch (Throwable ignored) { /* Divinity present but incompatible/misbehaving */ }
             }
             FlagManager.addFlag(target, key, ticks);
         }

--- a/src/main/java/studio/magemonkey/fabled/hook/DivinityHook.java
+++ b/src/main/java/studio/magemonkey/fabled/hook/DivinityHook.java
@@ -1,8 +1,14 @@
 package studio.magemonkey.fabled.hook;
 
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import studio.magemonkey.codex.util.DataUT;
+import studio.magemonkey.divinity.stats.EntityStats;
+import studio.magemonkey.divinity.stats.items.ItemStats;
+import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
+import studio.magemonkey.fabled.api.enums.Operation;
 
 public class DivinityHook {
     private static final NamespacedKey KEY_MODULE  = NamespacedKey.fromString("prorpgitems:qrpg_item_module");
@@ -15,4 +21,90 @@ public class DivinityHook {
         return data != null;
     }
 
+    /**
+     * Clamps a StatMechanic modifier amount so the resulting stat total does not exceed
+     * Divinity's configured cap for the given stat key.
+     * <p>
+     * Returns the original amount unchanged if the stat is unknown, has no cap (-1),
+     * or the operation is unrecognized.
+     * <p>
+     * NOTE: All Divinity class references are confined to this method body to allow
+     * lazy class-loading — this method must only be called when Divinity is confirmed active.
+     *
+     * @param key       Divinity stat key (e.g. "critical_rate")
+     * @param operation Fabled Operation (ADD_NUMBER or MULTIPLY_PERCENTAGE)
+     * @param amount    Modifier amount from the mechanic
+     * @param player    Target player
+     * @return clamped amount that will not push the stat past its Divinity cap
+     */
+    public static double clampStatAmount(String key, Operation operation, double amount, Player player) {
+        TypedStat.Type statType = TypedStat.Type.getByName(key);
+        if (statType == null) return amount;
+
+        TypedStat stat = ItemStats.getStat(statType);
+        if (stat == null) return amount;
+
+        double cap = stat.getCapability();
+        if (cap < 0) return amount; // unlimited cap
+
+        double currentValue = EntityStats.get(player).getItemStat(statType, true);
+
+        switch (operation) {
+            case ADD_NUMBER:
+                // Clamp: currentValue + amount <= cap  →  amount <= cap - currentValue
+                return Math.min(amount, Math.max(0, cap - currentValue));
+            case MULTIPLY_PERCENTAGE:
+                // New total = currentValue * amount; clamp: amount <= cap / currentValue
+                // Ensure we don't reduce the stat (amount >= 1.0)
+                if (currentValue <= 0) return amount;
+                if (currentValue >= cap) return 1.0; // already at/above cap, no-op multiplier
+                return Math.max(1.0, Math.min(amount, cap / currentValue));
+            default:
+                return amount;
+        }
+    }
+
+    /**
+     * Applies a temporary stat modifier to a non-player entity via Divinity's AdjustStatEffect.
+     * Returns the effect as Object to avoid eager class-loading of Divinity types in callers.
+     * Only call when Divinity is confirmed active.
+     *
+     * @param seconds negative value = permanent
+     * @return the created AdjustStatEffect, or null if stat key is unknown / operation invalid
+     */
+    public static Object applyStatToMob(LivingEntity target, LivingEntity caster,
+                                        String key, String operation, double amount, double seconds) {
+        studio.magemonkey.divinity.stats.items.api.ItemLoreStat<?> stat = ItemStats.getAttribute(key);
+        if (stat == null) return null;
+
+        java.util.function.DoubleUnaryOperator operator;
+        switch (operation) {
+            case "ADD_NUMBER":
+                operator = v -> v + amount;
+                break;
+            case "MULTIPLY_PERCENTAGE":
+                operator = v -> v * amount;
+                break;
+            default:
+                return null;
+        }
+
+        studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect effect =
+                new studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect.Builder(seconds)
+                        .withCaster(caster)
+                        .withAdjust(stat, operator)
+                        .build();
+        effect.applyTo(target);
+        return effect;
+    }
+
+    /**
+     * Removes a stat effect previously returned by {@link #applyStatToMob} from the target's EntityStats.
+     * Only call when Divinity is confirmed active.
+     */
+    public static void removeStatFromMob(LivingEntity target, Object effect) {
+        if (effect == null) return;
+        EntityStats.get(target).removeEffect(
+                (studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect) effect);
+    }
 }

--- a/src/main/java/studio/magemonkey/fabled/hook/DivinityHook.java
+++ b/src/main/java/studio/magemonkey/fabled/hook/DivinityHook.java
@@ -5,10 +5,14 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import studio.magemonkey.codex.util.DataUT;
+import studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect;
 import studio.magemonkey.divinity.stats.EntityStats;
 import studio.magemonkey.divinity.stats.items.ItemStats;
+import studio.magemonkey.divinity.stats.items.api.ItemLoreStat;
 import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 import studio.magemonkey.fabled.api.enums.Operation;
+
+import java.util.function.DoubleUnaryOperator;
 
 public class DivinityHook {
     private static final NamespacedKey KEY_MODULE  = NamespacedKey.fromString("prorpgitems:qrpg_item_module");
@@ -28,8 +32,7 @@ public class DivinityHook {
      * Returns the original amount unchanged if the stat is unknown, has no cap (-1),
      * or the operation is unrecognized.
      * <p>
-     * NOTE: All Divinity class references are confined to this method body to allow
-     * lazy class-loading — this method must only be called when Divinity is confirmed active.
+     * NOTE: this method must only be called when Divinity is confirmed active.
      *
      * @param key       Divinity stat key (e.g. "critical_rate")
      * @param operation Fabled Operation (ADD_NUMBER or MULTIPLY_PERCENTAGE)
@@ -66,7 +69,7 @@ public class DivinityHook {
 
     /**
      * Applies a temporary stat modifier to a non-player entity via Divinity's AdjustStatEffect.
-     * Returns the effect as Object to avoid eager class-loading of Divinity types in callers.
+     * Returns the effect as Object so callers don't need to reference Divinity types directly.
      * Only call when Divinity is confirmed active.
      *
      * @param seconds negative value = permanent
@@ -74,10 +77,10 @@ public class DivinityHook {
      */
     public static Object applyStatToMob(LivingEntity target, LivingEntity caster,
                                         String key, String operation, double amount, double seconds) {
-        studio.magemonkey.divinity.stats.items.api.ItemLoreStat<?> stat = ItemStats.getAttribute(key);
+        ItemLoreStat<?> stat = ItemStats.getAttribute(key);
         if (stat == null) return null;
 
-        java.util.function.DoubleUnaryOperator operator;
+        DoubleUnaryOperator operator;
         switch (operation) {
             case "ADD_NUMBER":
                 operator = v -> v + amount;
@@ -89,8 +92,8 @@ public class DivinityHook {
                 return null;
         }
 
-        studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect effect =
-                new studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect.Builder(seconds)
+        AdjustStatEffect effect =
+                new AdjustStatEffect.Builder(seconds)
                         .withCaster(caster)
                         .withAdjust(stat, operator)
                         .build();
@@ -104,7 +107,6 @@ public class DivinityHook {
      */
     public static void removeStatFromMob(LivingEntity target, Object effect) {
         if (effect == null) return;
-        EntityStats.get(target).removeEffect(
-                (studio.magemonkey.divinity.manager.effects.main.AdjustStatEffect) effect);
+        EntityStats.get(target).removeEffect((AdjustStatEffect) effect);
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/hook/PluginChecker.java
+++ b/src/main/java/studio/magemonkey/fabled/hook/PluginChecker.java
@@ -50,6 +50,7 @@ public class PluginChecker extends FabledListener {
     private static boolean parties;
     private static boolean mimic;
     private static boolean protocolLib;
+    private static boolean divinity;
 
     /**
      * Checks if vault permissions is active on the server
@@ -95,6 +96,8 @@ public class PluginChecker extends FabledListener {
 
     public static boolean isProtocolLibActive() {return protocolLib;}
 
+    public static boolean isDivinityActive() {return divinity;}
+
     public static boolean isPartiesActive() {
         return parties || Bukkit.getPluginManager()
                 .isPluginEnabled("FabledParties");
@@ -124,6 +127,7 @@ public class PluginChecker extends FabledListener {
         parties = pluginManager.isPluginEnabled("FabledParties");
         mimic = pluginManager.isPluginEnabled("Mimic");
         protocolLib = pluginManager.isPluginEnabled("ProtocolLib");
+        divinity = pluginManager.isPluginEnabled("Divinity");
     }
 
     @EventHandler
@@ -164,6 +168,9 @@ public class PluginChecker extends FabledListener {
                 break;
             case "ProtocolLib":
                 protocolLib = isEnabled;
+                break;
+            case "Divinity":
+                divinity = isEnabled;
                 break;
         }
     }

--- a/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/DurabilityMechanicTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/DurabilityMechanicTest.java
@@ -1,0 +1,67 @@
+package studio.magemonkey.fabled.dynamic.mechanic;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.hook.PluginChecker;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers DurabilityMechanic's Divinity durability integration is gated behind
+ * PluginChecker.isDivinityActive() - see HealMechanicTest for why an ungated call is a
+ * real crash risk on servers without Divinity installed.
+ */
+public class DurabilityMechanicTest extends MockedTest {
+    private Player caster;
+
+    @BeforeEach
+    void setup() {
+        caster = genPlayer("Travja");
+        caster.getInventory().setItemInMainHand(new ItemStack(Material.DIAMOND_SWORD));
+    }
+
+    private DurabilityMechanic getMechanic(double amount) {
+        DurabilityMechanic mechanic = new DurabilityMechanic();
+        DynamicSkill       skill    = new DynamicSkill("Durability");
+        DataSection        config   = new DataSection();
+        DataSection        data     = new DataSection();
+        data.set("amount-base", amount);
+        data.set("amount-scale", 0);
+        config.set("data", data);
+        mechanic.load(skill, config);
+        return mechanic;
+    }
+
+    @Test
+    void execute_divinityInactive_stillDamagesVanillaDurability() {
+        assertFalse(PluginChecker.isDivinityActive());
+
+        DurabilityMechanic mechanic = getMechanic(3);
+        boolean             result  = mechanic.execute(caster, 1, List.of(caster), false);
+
+        assertTrue(result);
+        ItemStack  item = caster.getInventory().getItemInMainHand();
+        Damageable meta = (Damageable) item.getItemMeta();
+        assertEquals(3, meta.getDamage());
+    }
+
+    @Test
+    void execute_divinityInactive_doesNotThrow() {
+        DurabilityMechanic mechanic = getMechanic(3);
+
+        // Regression guard: previously an ungated Divinity API call here would throw
+        // NoClassDefFoundError when Divinity isn't installed.
+        mechanic.execute(caster, 1, List.of(caster), false);
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/HealMechanicTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/HealMechanicTest.java
@@ -1,0 +1,65 @@
+package studio.magemonkey.fabled.dynamic.mechanic;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.hook.PluginChecker;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers HealMechanic's Divinity integration is properly gated behind
+ * PluginChecker.isDivinityActive() - without that guard, calling Divinity's
+ * EntityStats API on a server that doesn't have Divinity installed throws
+ * NoClassDefFoundError (a LinkageError, not an Exception), which the mechanic's own
+ * catch(Exception) can't catch.
+ */
+public class HealMechanicTest extends MockedTest {
+    private Player caster;
+
+    @BeforeEach
+    void setup() {
+        caster = genPlayer("Travja");
+        caster.setHealth(10);
+    }
+
+    private HealMechanic getMechanic(double value, boolean percent) {
+        HealMechanic mechanic = new HealMechanic();
+        DynamicSkill skill    = new DynamicSkill("Heal");
+        DataSection  config   = new DataSection();
+        DataSection  data     = new DataSection();
+        data.set("type", percent ? "percent" : "health");
+        data.set("value-base", value);
+        data.set("value-scale", 0);
+        config.set("data", data);
+        mechanic.load(skill, config);
+        return mechanic;
+    }
+
+    @Test
+    void execute_divinityInactive_appliesUnmodifiedHealAmount() {
+        assertFalse(PluginChecker.isDivinityActive());
+
+        HealMechanic mechanic = getMechanic(5, false);
+        boolean      result   = mechanic.execute(caster, 1, List.of(caster), false);
+
+        assertTrue(result);
+        assertEquals(15, caster.getHealth());
+    }
+
+    @Test
+    void execute_divinityInactive_doesNotThrow() {
+        HealMechanic mechanic = getMechanic(5, false);
+
+        // Regression guard: previously an ungated Divinity API call here would throw
+        // NoClassDefFoundError when Divinity isn't installed.
+        mechanic.execute(caster, 1, List.of(caster), false);
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/StatusMechanicTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/StatusMechanicTest.java
@@ -1,0 +1,64 @@
+package studio.magemonkey.fabled.dynamic.mechanic;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.api.util.FlagManager;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.hook.PluginChecker;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers StatusMechanic's Divinity CC-duration/CC-resistance integration is gated behind
+ * PluginChecker.isDivinityActive() - see HealMechanicTest for why an ungated call is a
+ * real crash risk on servers without Divinity installed.
+ */
+public class StatusMechanicTest extends MockedTest {
+    private Player caster;
+    private Player target;
+
+    @BeforeEach
+    void setup() {
+        caster = genPlayer("Caster");
+        target = genPlayer("Target");
+    }
+
+    private StatusMechanic getMechanic(String key, double durationSeconds) {
+        StatusMechanic mechanic = new StatusMechanic();
+        DynamicSkill   skill    = new DynamicSkill("Status");
+        DataSection    config   = new DataSection();
+        DataSection    data     = new DataSection();
+        data.set("status", key);
+        data.set("duration-base", durationSeconds);
+        data.set("duration-scale", 0);
+        config.set("data", data);
+        mechanic.load(skill, config);
+        return mechanic;
+    }
+
+    @Test
+    void execute_divinityInactive_stillAppliesFlag() {
+        assertFalse(PluginChecker.isDivinityActive());
+
+        StatusMechanic mechanic = getMechanic("stunned", 5.0);
+        boolean        result   = mechanic.execute(caster, 1, List.of(target), false);
+
+        assertTrue(result);
+        assertTrue(FlagManager.hasFlag(target, "stunned"));
+    }
+
+    @Test
+    void execute_divinityInactive_doesNotThrow() {
+        StatusMechanic mechanic = getMechanic("stunned", 5.0);
+
+        // Regression guard: previously an ungated Divinity API call here would throw
+        // NoClassDefFoundError when Divinity isn't installed.
+        mechanic.execute(caster, 1, List.of(target), false);
+    }
+}


### PR DESCRIPTION
Split out of #1677 (piece 2 of 8 — see that PR for the full breakdown).

## What
Adds `studio.magemonkey:divinity` as a `provided` dependency and a `PluginChecker.isDivinityActive()` flag, then wires several mechanics into it when active:

- **DivinityHook**: `clampStatAmount()` caps `StatMechanic` modifiers to Divinity's configured stat cap; `applyStatToMob()` / `removeStatFromMob()` apply temporary Divinity stat effects to non-player entities.
- **StatMechanic**: clamps player stat modifiers via Divinity's caps (unless `ignore-divinity-cap`), and can now apply stat effects to non-player mobs too.
- **HealMechanic**: applies Divinity's healing-cast/healing-received multipliers (skippable via new settings).
- **StatusMechanic**: applies Divinity's CC-duration multiplier and CC-resistance reduction to status flag durations.
- **DurabilityMechanic**: reduces Divinity-tracked item durability alongside vanilla durability.
- **DamageMechanic**: sets short-lived caster metadata flags (crit/dodge/block ignore, bleed/vamp disable, skill-crit ignore) around damage application, for Divinity's own damage listener to read.

All Divinity calls are guarded by `PluginChecker.isDivinityActive()` or wrapped in try/catch, so behavior should be unchanged when Divinity isn't installed.

## Why split out separately
This is the largest coherent feature in #1677 and has no dependency on the other split pieces. It's the one most worth extra review scrutiny since it adds an external plugin dependency and several new config options — testable in isolation with/without Divinity present.

## Testing
Could not build locally in this environment (private Maven repo `repo.travja.dev`, including the new `divinity` dependency, isn't reachable from the sandbox). Needs CI/manual verification, particularly: behavior with Divinity absent (should be a no-op), stat capping math, and the CC duration/resistance formulas.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCXEKdwwNjFkmjn46heQDM)_