### PR TITLE
feat: resolve dynamic placeholders in flag names

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/dynamic/condition/FlagCondition.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/condition/FlagCondition.java
@@ -38,7 +38,7 @@ public class FlagCondition extends ConditionComponent {
 
     @Override
     boolean test(final LivingEntity caster, final int level, final LivingEntity target) {
-        final String  flag = settings.getString(KEY);
+        final String  flag = filter(caster, target, settings.getString(KEY));
         final boolean set  = !settings.getString(TYPE, "set").toLowerCase().equals("not set");
         return FlagManager.hasFlag(target, flag) == set;
     }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagClearMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagClearMechanic.java
@@ -63,18 +63,21 @@ public class FlagClearMechanic extends MechanicComponent {
             return false;
         }
 
-        String  key      = settings.getString(KEY);
+        String  rawKey   = settings.getString(KEY);
         boolean useRegex = settings.getBool(REGEX, false);
+        boolean hadError = false;
 
         if (useRegex) {
-            Pattern pattern;
-            try {
-                pattern = Pattern.compile(key);
-            } catch (PatternSyntaxException e) {
-                Fabled.inst().getLogger().warning("Invalid regex pattern for flag clear mechanic: \"" + key + "\" - " + e.getDescription());
-                return false;
-            }
             for (LivingEntity target : targets) {
+                String key = filter(caster, target, rawKey);
+                Pattern pattern;
+                try {
+                    pattern = Pattern.compile(key);
+                } catch (PatternSyntaxException e) {
+                    Fabled.inst().getLogger().warning("Invalid regex pattern for flag clear mechanic: \"" + key + "\" - " + e.getDescription());
+                    hadError = true;
+                    continue;
+                }
                 FlagData data = FlagManager.getFlagData(target, false);
                 if (data != null) {
                     new HashSet<>(data.flagList()).stream()
@@ -84,9 +87,10 @@ public class FlagClearMechanic extends MechanicComponent {
             }
         } else {
             for (LivingEntity target : targets) {
+                String key = filter(caster, target, rawKey);
                 FlagManager.removeFlag(target, key);
             }
         }
-        return targets.size() > 0;
+        return targets.size() > 0 && !hadError;
     }
 }

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagMechanic.java
@@ -58,10 +58,11 @@ public class FlagMechanic extends MechanicComponent {
             return false;
         }
 
-        String key     = settings.getString(KEY);
+        String rawKey  = settings.getString(KEY);
         double seconds = parseValues(caster, SECONDS, level, 3.0);
         int    ticks   = (int) (seconds * 20);
         for (LivingEntity target : targets) {
+            String key = filter(caster, target, rawKey);
             FlagManager.addFlag(target, key, ticks);
         }
         return targets.size() > 0;

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagToggleMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/FlagToggleMechanic.java
@@ -57,8 +57,9 @@ public class FlagToggleMechanic extends MechanicComponent {
             return false;
         }
 
-        String key = settings.getString(KEY);
+        String rawKey = settings.getString(KEY);
         for (LivingEntity target : targets) {
+            String key = filter(caster, target, rawKey);
             if (FlagManager.hasFlag(target, key)) {
                 FlagManager.removeFlag(target, key);
             } else {

--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/FlagExpireTrigger.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/FlagExpireTrigger.java
@@ -4,8 +4,11 @@ import org.bukkit.entity.LivingEntity;
 import studio.magemonkey.fabled.api.CastData;
 import studio.magemonkey.fabled.api.Settings;
 import studio.magemonkey.fabled.api.event.FlagExpireEvent;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FlagExpireTrigger implements Trigger<FlagExpireEvent> {
 
@@ -30,9 +33,34 @@ public class FlagExpireTrigger implements Trigger<FlagExpireEvent> {
      */
     @Override
     public boolean shouldTrigger(final FlagExpireEvent event, final int level, final Settings settings) {
-        final List<String> flags = settings.getStringList("flags");
-        final boolean inverted  = settings.getBool("inverted", false);
-        return (flags.isEmpty() || flags.contains("Any") || flags.contains(event.getFlag())) != inverted;
+        final List<String> flags    = settings.getStringList("flags");
+        final boolean      inverted = settings.getBool("inverted", false);
+
+        final LivingEntity entity = getCaster(event);
+        return (flags.isEmpty()
+                || flags.contains("Any")
+                || flags.stream().anyMatch(f -> filterFlag(entity, f).equals(event.getFlag()))) != inverted;
+    }
+
+    /**
+     * Resolves dynamic variables in a flag name using the given entity's cast data.
+     * Mirrors EffectComponent#filter — entity acts as both caster and target.
+     * Note: for cross-entity skills {player} resolves to the entity whose flag
+     * expired, not the original caster.
+     */
+    private String filterFlag(final LivingEntity entity, String text) {
+        CastData data  = DynamicSkill.getCastData(entity);
+        Pattern  pat   = Pattern.compile("\\{[^{}]+}");
+        Matcher  match = pat.matcher(text);
+        while (match.find()) {
+            String key = match.group().substring(1, match.group().length() - 1);
+            if (data.contains(key))            text = text.replace(match.group(), data.get(key));
+            else if (key.equals("player"))     text = text.replace(match.group(), entity.getName());
+            else if (key.equals("target"))     text = text.replace(match.group(), entity.getName());
+            else if (key.equals("targetUUID")) text = text.replace(match.group(), entity.getUniqueId().toString());
+            match = pat.matcher(text);
+        }
+        return text;
     }
 
     /**
@@ -41,7 +69,7 @@ public class FlagExpireTrigger implements Trigger<FlagExpireEvent> {
     // Removes flag duration as a usable Value if it is set
     @Override
     public void setValues(final FlagExpireEvent event, final CastData data) {
-        data.remove("api-"+event.getFlag()+"-duration");
+        data.remove("api-" + event.getFlag() + "-duration");
     }
 
     /**

--- a/src/main/java/studio/magemonkey/fabled/dynamic/trigger/FlagTrigger.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/trigger/FlagTrigger.java
@@ -4,8 +4,11 @@ import org.bukkit.entity.LivingEntity;
 import studio.magemonkey.fabled.api.CastData;
 import studio.magemonkey.fabled.api.Settings;
 import studio.magemonkey.fabled.api.event.FlagApplyEvent;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FlagTrigger implements Trigger<FlagApplyEvent> {
 
@@ -30,16 +33,41 @@ public class FlagTrigger implements Trigger<FlagApplyEvent> {
      */
     @Override
     public boolean shouldTrigger(final FlagApplyEvent event, final int level, final Settings settings) {
-        final List<String> flags = settings.getStringList("flags");
-        final boolean inverted  = settings.getBool("inverted", false);
-        final double minDuration = settings.getDouble("min-duration", 0);
-        final int ticks = (int) minDuration * 20;
+        final List<String> flags       = settings.getStringList("flags");
+        final boolean      inverted    = settings.getBool("inverted", false);
+        final double       minDuration = settings.getDouble("min-duration", 0);
+        final int          ticks       = (int) (minDuration * 20);
 
-        // Return False if the Flaf 
-        if (event.getTicks() < ticks){
+        // Return false if the flag duration is shorter than the required minimum
+        if (event.getTicks() < ticks) {
             return false;
-        };
-        return (flags.isEmpty() || flags.contains("Any") || flags.contains(event.getFlag())) != inverted;
+        }
+
+        final LivingEntity entity = getCaster(event);
+        return (flags.isEmpty()
+                || flags.contains("Any")
+                || flags.stream().anyMatch(f -> filterFlag(entity, f).equals(event.getFlag()))) != inverted;
+    }
+
+    /**
+     * Resolves dynamic variables in a flag name using the given entity's cast data.
+     * Mirrors EffectComponent#filter — entity acts as both caster and target.
+     * Note: for cross-entity skills {player} resolves to the entity that received
+     * the flag, not the original caster.
+     */
+    private String filterFlag(final LivingEntity entity, String text) {
+        CastData data  = DynamicSkill.getCastData(entity);
+        Pattern  pat   = Pattern.compile("\\{[^{}]+}");
+        Matcher  match = pat.matcher(text);
+        while (match.find()) {
+            String key = match.group().substring(1, match.group().length() - 1);
+            if (data.contains(key))            text = text.replace(match.group(), data.get(key));
+            else if (key.equals("player"))     text = text.replace(match.group(), entity.getName());
+            else if (key.equals("target"))     text = text.replace(match.group(), entity.getName());
+            else if (key.equals("targetUUID")) text = text.replace(match.group(), entity.getUniqueId().toString());
+            match = pat.matcher(text);
+        }
+        return text;
     }
 
     /**
@@ -48,7 +76,7 @@ public class FlagTrigger implements Trigger<FlagApplyEvent> {
     // Adds flag duration as a usable Value
     @Override
     public void setValues(final FlagApplyEvent event, final CastData data) {
-        data.put("api-"+event.getFlag()+"-duration", event.getTicks());
+        data.put("api-" + event.getFlag() + "-duration", event.getTicks());
     }
 
     /**

--- a/src/test/java/studio/magemonkey/fabled/dynamic/condition/FlagConditionTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/condition/FlagConditionTest.java
@@ -1,0 +1,75 @@
+package studio.magemonkey.fabled.dynamic.condition;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.util.FlagManager;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mockStatic;
+
+public class FlagConditionTest extends MockedTest {
+    private Player                     caster;
+    private Player                     target;
+    private MockedStatic<DynamicSkill> dynamicSkill;
+    private CastData                   data;
+
+    @BeforeEach
+    public void setup() {
+        caster = genPlayer("Travja");
+        target = genPlayer("goflish");
+        dynamicSkill = mockStatic(DynamicSkill.class);
+        data = new CastData(caster);
+        dynamicSkill.when(() -> DynamicSkill.getCastData(any())).thenReturn(data);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        dynamicSkill.close();
+        dynamicSkill = null;
+    }
+
+    private FlagCondition getCondition(String key, String type) {
+        FlagCondition condition = new FlagCondition();
+        DataSection   config    = new DataSection();
+        DataSection   settings  = new DataSection();
+        settings.set("key", key);
+        if (type != null) settings.set("type", type);
+        config.set("data", settings);
+        condition.load(null, config);
+        return condition;
+    }
+
+    @Test
+    void test_staticKey_matchesFlagOnTarget() {
+        FlagManager.addFlag(target, "stunned", 100);
+
+        FlagCondition condition = getCondition("stunned", "set");
+        assertTrue(condition.test(caster, 1, target));
+    }
+
+    @Test
+    void test_dynamicTargetPlaceholder_resolvesAgainstTargetFlag() {
+        FlagManager.addFlag(target, "marked-" + target.getName(), 100);
+
+        FlagCondition condition = getCondition("marked-{target}", "set");
+        assertTrue(condition.test(caster, 1, target));
+    }
+
+    @Test
+    void test_notSet_returnsTrueWhenFlagAbsent() {
+        FlagCondition condition = getCondition("stunned", "not set");
+        assertTrue(condition.test(caster, 1, target));
+
+        FlagManager.addFlag(target, "stunned", 100);
+        assertFalse(condition.test(caster, 1, target));
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/FlagClearMechanicTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/FlagClearMechanicTest.java
@@ -1,9 +1,12 @@
 package studio.magemonkey.fabled.dynamic.mechanic;
 
 import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.api.CastData;
 import studio.magemonkey.fabled.api.util.FlagManager;
 import studio.magemonkey.fabled.dynamic.DynamicSkill;
 import studio.magemonkey.fabled.testutil.MockedTest;
@@ -11,13 +14,26 @@ import studio.magemonkey.fabled.testutil.MockedTest;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mockStatic;
 
 public class FlagClearMechanicTest extends MockedTest {
-    private Player player;
+    private Player                     player;
+    private MockedStatic<DynamicSkill> dynamicSkill;
+    private CastData                   data;
 
     @BeforeEach
     public void setup() {
         player = this.genPlayer("Travja");
+        dynamicSkill = mockStatic(DynamicSkill.class);
+        data = new CastData(player);
+        dynamicSkill.when(() -> DynamicSkill.getCastData(any())).thenReturn(data);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        dynamicSkill.close();
+        dynamicSkill = null;
     }
 
     private FlagClearMechanic getMechanic(String key, boolean regex) {
@@ -107,5 +123,48 @@ public class FlagClearMechanicTest extends MockedTest {
         boolean result = mechanic.execute(player, 1, List.of(), false);
 
         assertFalse(result);
+    }
+
+    @Test
+    void execute_dynamicKey_resolvesPlaceholderBeforeRemoving() {
+        FlagManager.addFlag(player, "marked-" + player.getName(), 100);
+
+        FlagClearMechanic mechanic = getMechanic("marked-{player}", false);
+        boolean result = mechanic.execute(player, 1, List.of(player), false);
+
+        assertTrue(result);
+        assertFalse(FlagManager.hasFlag(player, "marked-" + player.getName()));
+    }
+
+    @Test
+    void execute_dynamicKey_regexResolvesPerTargetBeforeCompiling() {
+        Player other = this.genPlayer("Other");
+        FlagManager.addFlag(player, "effect_" + player.getName(), 100);
+        FlagManager.addFlag(other, "effect_" + other.getName(), 100);
+
+        FlagClearMechanic mechanic = getMechanic("effect_{target}", true);
+        boolean result = mechanic.execute(player, 1, List.of(player, other), false);
+
+        assertTrue(result);
+        assertFalse(FlagManager.hasFlag(player, "effect_" + player.getName()));
+        assertFalse(FlagManager.hasFlag(other, "effect_" + other.getName()));
+    }
+
+    @Test
+    void execute_dynamicKey_regexFailureForOneTargetSkipsOnlyThatTarget() {
+        // A target name containing a regex metacharacter makes the resolved pattern
+        // invalid for that target only, once {target} is substituted in.
+        Player invalidNamed = this.genPlayer("Bad(Name");
+        Player validNamed   = this.genPlayer("Good");
+
+        FlagManager.addFlag(invalidNamed, "untouched", 100);
+        FlagManager.addFlag(validNamed, "flag_Good", 100);
+
+        FlagClearMechanic mechanic = getMechanic("flag_{target}", true);
+        boolean result = mechanic.execute(player, 1, List.of(invalidNamed, validNamed), false);
+
+        assertFalse(result); // overall failure reported because one target's regex didn't compile
+        assertTrue(FlagManager.hasFlag(invalidNamed, "untouched")); // that target was skipped, not touched
+        assertFalse(FlagManager.hasFlag(validNamed, "flag_Good")); // other target still processed normally
     }
 }

--- a/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/FlagMechanicTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/FlagMechanicTest.java
@@ -1,0 +1,84 @@
+package studio.magemonkey.fabled.dynamic.mechanic;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.util.FlagManager;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mockStatic;
+
+public class FlagMechanicTest extends MockedTest {
+    private Player                     caster;
+    private Player                     target;
+    private MockedStatic<DynamicSkill> dynamicSkill;
+    private CastData                   data;
+
+    @BeforeEach
+    public void setup() {
+        caster = genPlayer("Travja");
+        target = genPlayer("goflish");
+        dynamicSkill = mockStatic(DynamicSkill.class);
+        data = new CastData(caster);
+        dynamicSkill.when(() -> DynamicSkill.getCastData(any())).thenReturn(data);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        dynamicSkill.close();
+        dynamicSkill = null;
+    }
+
+    private FlagMechanic getMechanic(String key) {
+        FlagMechanic  mechanic = new FlagMechanic();
+        DynamicSkill  skill    = new DynamicSkill("Flag");
+        DataSection   config   = new DataSection();
+        DataSection   settings = new DataSection();
+        settings.set("key", key);
+        settings.set("seconds", 5.0);
+        config.set("data", settings);
+        mechanic.load(skill, config);
+        return mechanic;
+    }
+
+    @Test
+    void execute_staticKey_appliesLiteralFlag() {
+        FlagMechanic mechanic = getMechanic("stunned");
+        boolean      result   = mechanic.execute(caster, 1, List.of(target), false);
+
+        assertTrue(result);
+        assertTrue(FlagManager.hasFlag(target, "stunned"));
+    }
+
+    @Test
+    void execute_dynamicKey_resolvesPerTargetPlaceholder() {
+        Player secondTarget = genPlayer("Secondary");
+
+        FlagMechanic mechanic = getMechanic("marked-{target}");
+        mechanic.execute(caster, 1, List.of(target, secondTarget), false);
+
+        assertTrue(FlagManager.hasFlag(target, "marked-" + target.getName()));
+        assertTrue(FlagManager.hasFlag(secondTarget, "marked-" + secondTarget.getName()));
+        assertFalse(FlagManager.hasFlag(target, "marked-" + secondTarget.getName()));
+    }
+
+    @Test
+    void execute_dynamicKey_resolvesCastDataPlaceholder() {
+        data.put("element", "fire");
+
+        FlagMechanic mechanic = getMechanic("burning-{element}");
+        mechanic.execute(caster, 1, List.of(target), false);
+
+        assertTrue(FlagManager.hasFlag(target, "burning-fire"));
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/FlagToggleMechanicTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/FlagToggleMechanicTest.java
@@ -1,0 +1,80 @@
+package studio.magemonkey.fabled.dynamic.mechanic;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.util.FlagManager;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mockStatic;
+
+public class FlagToggleMechanicTest extends MockedTest {
+    private Player                     caster;
+    private Player                     target;
+    private MockedStatic<DynamicSkill> dynamicSkill;
+    private CastData                   data;
+
+    @BeforeEach
+    public void setup() {
+        caster = genPlayer("Travja");
+        target = genPlayer("goflish");
+        dynamicSkill = mockStatic(DynamicSkill.class);
+        data = new CastData(caster);
+        dynamicSkill.when(() -> DynamicSkill.getCastData(any())).thenReturn(data);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        dynamicSkill.close();
+        dynamicSkill = null;
+    }
+
+    private FlagToggleMechanic getMechanic(String key) {
+        FlagToggleMechanic mechanic = new FlagToggleMechanic();
+        DynamicSkill       skill    = new DynamicSkill("FlagToggle");
+        DataSection        config   = new DataSection();
+        DataSection        settings = new DataSection();
+        settings.set("key", key);
+        config.set("data", settings);
+        mechanic.load(skill, config);
+        return mechanic;
+    }
+
+    @Test
+    void execute_staticKey_togglesFlagOnAndOff() {
+        FlagToggleMechanic mechanic = getMechanic("stunned");
+
+        mechanic.execute(caster, 1, List.of(target), false);
+        assertTrue(FlagManager.hasFlag(target, "stunned"));
+
+        mechanic.execute(caster, 1, List.of(target), false);
+        assertFalse(FlagManager.hasFlag(target, "stunned"));
+    }
+
+    @Test
+    void execute_dynamicKey_resolvesPerTargetBeforeToggling() {
+        Player secondTarget = genPlayer("Secondary");
+
+        FlagToggleMechanic mechanic = getMechanic("marked-{target}");
+        mechanic.execute(caster, 1, List.of(target, secondTarget), false);
+
+        assertTrue(FlagManager.hasFlag(target, "marked-" + target.getName()));
+        assertTrue(FlagManager.hasFlag(secondTarget, "marked-" + secondTarget.getName()));
+
+        // Toggling again should resolve the same per-target key and remove it, not the
+        // literal "marked-{target}" string.
+        mechanic.execute(caster, 1, List.of(target, secondTarget), false);
+        assertFalse(FlagManager.hasFlag(target, "marked-" + target.getName()));
+        assertFalse(FlagManager.hasFlag(secondTarget, "marked-" + secondTarget.getName()));
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/trigger/FlagExpireTriggerTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/trigger/FlagExpireTriggerTest.java
@@ -1,0 +1,93 @@
+package studio.magemonkey.fabled.dynamic.trigger;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.Settings;
+import studio.magemonkey.fabled.api.event.FlagExpireEvent;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mockStatic;
+
+class FlagExpireTriggerTest extends MockedTest {
+    private FlagExpireTrigger          trigger;
+    private Player                     entity;
+    private MockedStatic<DynamicSkill> dynamicSkill;
+    private CastData                   data;
+
+    @BeforeEach
+    void setup() {
+        trigger = new FlagExpireTrigger();
+        entity = genPlayer("Travja");
+        dynamicSkill = mockStatic(DynamicSkill.class);
+        data = new CastData(entity);
+        dynamicSkill.when(() -> DynamicSkill.getCastData(any())).thenReturn(data);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dynamicSkill.close();
+        dynamicSkill = null;
+    }
+
+    private Settings settingsWithFlags(List<String> flags) {
+        Settings settings = new Settings();
+        settings.set("flags", flags);
+        return settings;
+    }
+
+    @Test
+    void shouldTrigger_staticFlagMatch() {
+        FlagExpireEvent event =
+                new FlagExpireEvent(entity, "stunned", FlagExpireEvent.ExpireReason.TIME);
+        assertTrue(trigger.shouldTrigger(event, 1, settingsWithFlags(List.of("stunned"))));
+    }
+
+    @Test
+    void shouldTrigger_dynamicPlayerPlaceholder_resolvesAgainstEntityName() {
+        FlagExpireEvent event = new FlagExpireEvent(entity, "marked-" + entity.getName(),
+                FlagExpireEvent.ExpireReason.REMOVED);
+        assertTrue(trigger.shouldTrigger(event, 1, settingsWithFlags(List.of("marked-{player}"))));
+    }
+
+    @Test
+    void shouldTrigger_dynamicCastDataPlaceholder() {
+        data.put("element", "fire");
+        FlagExpireEvent event =
+                new FlagExpireEvent(entity, "burning-fire", FlagExpireEvent.ExpireReason.TIME);
+        assertTrue(trigger.shouldTrigger(event, 1, settingsWithFlags(List.of("burning-{element}"))));
+    }
+
+    @Test
+    void shouldTrigger_dynamicPlaceholder_noMatchWhenResolvedDiffers() {
+        FlagExpireEvent event =
+                new FlagExpireEvent(entity, "marked-someoneElse", FlagExpireEvent.ExpireReason.TIME);
+        assertFalse(trigger.shouldTrigger(event, 1, settingsWithFlags(List.of("marked-{player}"))));
+    }
+
+    @Test
+    void shouldTrigger_emptyFlagsList_matchesAny() {
+        FlagExpireEvent event =
+                new FlagExpireEvent(entity, "anything", FlagExpireEvent.ExpireReason.TIME);
+        assertTrue(trigger.shouldTrigger(event, 1, settingsWithFlags(Collections.emptyList())));
+    }
+
+    @Test
+    void shouldTrigger_inverted_flipsMatch() {
+        FlagExpireEvent event =
+                new FlagExpireEvent(entity, "stunned", FlagExpireEvent.ExpireReason.TIME);
+        Settings settings = settingsWithFlags(List.of("stunned"));
+        settings.set("inverted", true);
+        assertFalse(trigger.shouldTrigger(event, 1, settings));
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/trigger/FlagTriggerTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/trigger/FlagTriggerTest.java
@@ -1,0 +1,87 @@
+package studio.magemonkey.fabled.dynamic.trigger;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import studio.magemonkey.fabled.api.CastData;
+import studio.magemonkey.fabled.api.Settings;
+import studio.magemonkey.fabled.api.event.FlagApplyEvent;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mockStatic;
+
+class FlagTriggerTest extends MockedTest {
+    private FlagTrigger                trigger;
+    private Player                     entity;
+    private MockedStatic<DynamicSkill> dynamicSkill;
+    private CastData                   data;
+
+    @BeforeEach
+    void setup() {
+        trigger = new FlagTrigger();
+        entity = genPlayer("Travja");
+        dynamicSkill = mockStatic(DynamicSkill.class);
+        data = new CastData(entity);
+        dynamicSkill.when(() -> DynamicSkill.getCastData(any())).thenReturn(data);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dynamicSkill.close();
+        dynamicSkill = null;
+    }
+
+    private Settings settingsWithFlags(List<String> flags) {
+        Settings settings = new Settings();
+        settings.set("flags", flags);
+        return settings;
+    }
+
+    @Test
+    void shouldTrigger_staticFlagMatch() {
+        FlagApplyEvent event = new FlagApplyEvent(entity, "stunned", 100);
+        assertTrue(trigger.shouldTrigger(event, 1, settingsWithFlags(List.of("stunned"))));
+    }
+
+    @Test
+    void shouldTrigger_dynamicPlayerPlaceholder_resolvesAgainstEntityName() {
+        FlagApplyEvent event = new FlagApplyEvent(entity, "marked-" + entity.getName(), 100);
+        assertTrue(trigger.shouldTrigger(event, 1, settingsWithFlags(List.of("marked-{player}"))));
+    }
+
+    @Test
+    void shouldTrigger_dynamicCastDataPlaceholder() {
+        data.put("element", "fire");
+        FlagApplyEvent event = new FlagApplyEvent(entity, "burning-fire", 100);
+        assertTrue(trigger.shouldTrigger(event, 1, settingsWithFlags(List.of("burning-{element}"))));
+    }
+
+    @Test
+    void shouldTrigger_dynamicPlaceholder_noMatchWhenResolvedDiffers() {
+        FlagApplyEvent event = new FlagApplyEvent(entity, "marked-someoneElse", 100);
+        assertFalse(trigger.shouldTrigger(event, 1, settingsWithFlags(List.of("marked-{player}"))));
+    }
+
+    @Test
+    void shouldTrigger_emptyFlagsList_matchesAny() {
+        FlagApplyEvent event = new FlagApplyEvent(entity, "anything", 100);
+        assertTrue(trigger.shouldTrigger(event, 1, settingsWithFlags(Collections.emptyList())));
+    }
+
+    @Test
+    void shouldTrigger_minDurationNotMet_returnsFalse() {
+        FlagApplyEvent event = new FlagApplyEvent(entity, "stunned", 10);
+        Settings settings = settingsWithFlags(List.of("stunned"));
+        settings.set("min-duration", 5.0);
+        assertFalse(trigger.shouldTrigger(event, 1, settings));
+    }
+}


### PR DESCRIPTION
Split out of #1677 (piece 5 of 8 — see that PR for the full breakdown).

## What
Flag names/keys are matched literally today, so a skill can't build a flag name from cast data (e.g. per-target flags like `stun-{targetUUID}`). This resolves `{player}`, `{target}`, `{targetUUID}`, and any custom cast-data keys in flag names consistently across both the producing and consuming sides:

- `FlagMechanic`, `FlagToggleMechanic`, `FlagClearMechanic`: apply `EffectComponent#filter()` to the configured flag key/name before use.
- `FlagTrigger`, `FlagExpireTrigger`: resolve the same placeholders when matching a fired/expired flag against the configured `flags` list, mirroring `EffectComponent#filter` with the trigger's caster entity acting as both caster and target.
- `FlagCondition`: applies `filter()` to the configured flag name.
- `FlagClearMechanic` (regex mode): a pattern that fails to compile for one target's resolved key now skips just that target (and the mechanic reports failure) instead of aborting entirely.

Also cleans up a couple of minor pre-existing issues noticed in the same files (min-duration tick math, a stray semicolon in `FlagTrigger`).

## Why split out separately
Cohesive, testable unit around one feature (dynamic flag names) touching only the flag subsystem. Independent of the `FlagManager` reentrancy fix (#1777) and everything else in #1677.

## Testing
Could not build locally (private Maven repo unreachable in this sandbox). Needs manual/CI verification: a skill using `{targetUUID}`-style flag names, plus regression-testing existing static flag names still match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCXEKdwwNjFkmjn46heQDM)_