### PR TITLE
fix: small independent mechanic/condition/registry fixes

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/api/skills/Skill.java
+++ b/src/main/java/studio/magemonkey/fabled/api/skills/Skill.java
@@ -873,20 +873,23 @@ public abstract class Skill implements IconHolder {
         target.setNoDamageTicks(0);
         skillDamage = true;
 
-        Vector velocity = target.getVelocity();
-        if (noShake)
-            BuffManager.addBuff(target, BuffType.NO_SCREEN_SHAKE, new Buff("damage-" + classification, 0, false), 1);
-        if (!DamageRegistry.dealDamage(target, damage, classification, source))
-            target.damage(damage, source);
-        if (!knockback)
-            target.setVelocity(velocity);
+        try {
+            Vector velocity = target.getVelocity();
+            if (noShake)
+                BuffManager.addBuff(target, BuffType.NO_SCREEN_SHAKE, new Buff("damage-" + classification, 0, false), 1);
+            if (!DamageRegistry.dealDamage(target, damage, classification, source))
+                target.damage(damage, source);
+            if (!knockback)
+                target.setVelocity(velocity);
 
-        // Reset damage timer to before the damage was applied
-        target.setNoDamageTicks(ticks);
-        if (source instanceof Player) {
-            if (PluginChecker.isNoCheatActive()) NoCheatHook.unexempt((Player) source);
+            // Reset damage timer to before the damage was applied
+            target.setNoDamageTicks(ticks);
+            if (source instanceof Player) {
+                if (PluginChecker.isNoCheatActive()) NoCheatHook.unexempt((Player) source);
+            }
+        } finally {
+            skillDamage = false;
         }
-        skillDamage = false;
     }
 
     /**

--- a/src/main/java/studio/magemonkey/fabled/dynamic/ComponentRegistry.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/ComponentRegistry.java
@@ -98,6 +98,7 @@ public class ComponentRegistry {
         register(new RememberTarget());
         register(new SelfTarget());
         register(new SingleTarget());
+        register(new WorldTarget());
 
         // Conditions
         register(new ActionBarCondition());

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RepeatMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RepeatMechanic.java
@@ -39,10 +39,11 @@ import java.util.Map;
  * Executes child components multiple times
  */
 public class RepeatMechanic extends MechanicComponent {
-    private static final String REPETITIONS  = "repetitions";
-    private static final String DELAY        = "delay";
-    private static final String PERIOD       = "period";
-    private static final String STOP_ON_FAIL = "stop-on-fail";
+    private static final String REPETITIONS     = "repetitions";
+    private static final String DELAY           = "delay";
+    private static final String PERIOD          = "period";
+    private static final String STOP_ON_FAIL    = "stop-on-fail";
+    private static final String SINGLE_INSTANCE = "single-instance";
 
     private final Map<Integer, List<RepeatTask>> tasks = new HashMap<>();
 
@@ -63,9 +64,19 @@ public class RepeatMechanic extends MechanicComponent {
                 return false;
             }
 
-            final int     delay      = (int) (settings.getDouble(DELAY, 0.0) * 20);
-            final int     period     = (int) (settings.getDouble(PERIOD, 1.0) * 20);
-            final boolean stopOnFail = settings.getBool(STOP_ON_FAIL, false);
+            final int     delay          = (int) (settings.getDouble(DELAY, 0.0) * 20);
+            final int     period         = (int) (settings.getDouble(PERIOD, 1.0) * 20);
+            final boolean stopOnFail     = settings.getBool(STOP_ON_FAIL, false);
+            final boolean singleInstance = settings.getBool(SINGLE_INSTANCE, false);
+
+            // Cancel all existing tasks for this caster when single-instance is enabled
+            if (singleInstance) {
+                final List<RepeatTask> existing = tasks.remove(caster.getEntityId());
+                if (existing != null) {
+                    existing.forEach(RepeatTask::cancel);
+                }
+            }
+
             if (period <= 0) {
                 // 0 tick loop
                 while (count > 0) {

--- a/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RepeatMechanic.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/mechanic/RepeatMechanic.java
@@ -45,7 +45,7 @@ public class RepeatMechanic extends MechanicComponent {
     private static final String STOP_ON_FAIL    = "stop-on-fail";
     private static final String SINGLE_INSTANCE = "single-instance";
 
-    private final Map<Integer, List<RepeatTask>> tasks = new HashMap<>();
+    final Map<Integer, List<RepeatTask>> tasks = new HashMap<>();
 
     /**
      * Executes the component

--- a/src/main/java/studio/magemonkey/fabled/dynamic/target/TargetComponent.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/target/TargetComponent.java
@@ -116,7 +116,7 @@ public abstract class TargetComponent extends EffectComponent {
         if (target instanceof Player && (((Player) target).getGameMode() == GameMode.SPECTATOR
                 || ((Player) target).getGameMode() == GameMode.CREATIVE)) return false;
 
-        return target != caster && Fabled.getSettings().isValidTarget(target) && (throughWall
+        return (self != IncludeCaster.FALSE || target != caster) && Fabled.getSettings().isValidTarget(target) && (throughWall
                 || !TargetHelper.isObstructed(from.getEyeLocation(), target.getEyeLocation())) && (everyone
                 || allies == Fabled.getSettings().isAlly(caster, target));
     }

--- a/src/test/java/studio/magemonkey/fabled/api/skills/SkillDamageResetTest.java
+++ b/src/test/java/studio/magemonkey/fabled/api/skills/SkillDamageResetTest.java
@@ -1,0 +1,54 @@
+package studio.magemonkey.fabled.api.skills;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import studio.magemonkey.codex.registry.DamageRegistry;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Covers Skill#damage's try-finally: the static skillDamage flag must always be reset,
+ * even if applying the damage throws, so a failure mid-damage doesn't leave the API
+ * reporting every subsequent damage event as skill-caused.
+ */
+public class SkillDamageResetTest extends MockedTest {
+    private Player caster;
+    private Skill  skill;
+
+    @BeforeEach
+    void setup() {
+        caster = genPlayer("Caster");
+        skill = new Skill("test", "test", Material.APPLE, 5) {
+        };
+    }
+
+    @Test
+    void damage_exceptionDuringApplication_stillResetsSkillDamageFlag() {
+        try (MockedStatic<DamageRegistry> damageRegistry = mockStatic(DamageRegistry.class)) {
+            damageRegistry.when(() -> DamageRegistry.dealDamage(any(), anyDouble(), any(), any()))
+                    .thenThrow(new RuntimeException("boom"));
+
+            // Self-damage keeps Fabled's canAttack check trivially true (attacker == target)
+            // so the failure being tested is isolated to the try block itself.
+            assertThrows(RuntimeException.class,
+                    () -> skill.damage(caster, 5, caster, "physical", true, true));
+        }
+
+        assertFalse(Skill.isSkillDamage());
+    }
+
+    @Test
+    void damage_normalCase_resetsSkillDamageFlagAfterward() {
+        skill.damage(caster, 5, caster, "physical", true, true);
+
+        assertFalse(Skill.isSkillDamage());
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/ComponentRegistryWorldTargetTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/ComponentRegistryWorldTargetTest.java
@@ -1,0 +1,22 @@
+package studio.magemonkey.fabled.dynamic;
+
+import org.junit.jupiter.api.Test;
+import studio.magemonkey.fabled.dynamic.target.WorldTarget;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * WorldTarget existed but was never registered as a usable target component - covers
+ * that it's now selectable like any other target.
+ */
+public class ComponentRegistryWorldTargetTest extends MockedTest {
+    @Test
+    void worldTarget_isRegisteredAsTargetComponent() {
+        String key = new WorldTarget().getKey();
+
+        assertTrue(ComponentRegistry.getComponents()
+                .get(ComponentType.TARGET)
+                .containsKey(key));
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/RepeatMechanicTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/mechanic/RepeatMechanicTest.java
@@ -1,0 +1,86 @@
+package studio.magemonkey.fabled.dynamic.mechanic;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RepeatMechanicTest extends MockedTest {
+    private Player player;
+
+    @BeforeEach
+    public void setup() {
+        player = this.genPlayer("Travja");
+        // The caster must be considered "active" and not cancelled for the repeat's
+        // per-tick execute() (and thus task scheduling) to keep going; DynamicSkill's
+        // default skill/level lookups need real class/skill data behind them, so route
+        // through Fabled's dynamic skill registration like other mechanic tests do.
+    }
+
+    private RepeatMechanic getMechanic(int repetitions, double delay, double period, boolean singleInstance) {
+        RepeatMechanic mechanic = new RepeatMechanic();
+
+        DynamicSkill skill  = new DynamicSkill("Repeat");
+        DataSection  config = new DataSection();
+        DataSection  data   = new DataSection();
+        data.set("repetitions-base", (double) repetitions);
+        data.set("repetitions-scale", 0);
+        data.set("delay", delay);
+        data.set("period", period);
+        data.set("single-instance", singleInstance);
+        config.set("data", data);
+
+        mechanic.load(skill, config);
+        return mechanic;
+    }
+
+    @Test
+    void execute_withoutSingleInstance_stacksMultipleTasks() {
+        RepeatMechanic mechanic = getMechanic(3, 0, 1, false);
+
+        mechanic.execute(player, 1, List.of(player), true);
+        mechanic.execute(player, 1, List.of(player), true);
+
+        assertEquals(2, mechanic.tasks.get(player.getEntityId()).size());
+    }
+
+    @Test
+    void execute_singleInstance_cancelsPreviousTaskBeforeStartingNew() {
+        RepeatMechanic mechanic = getMechanic(3, 0, 1, true);
+
+        mechanic.execute(player, 1, List.of(player), true);
+        assertEquals(1, mechanic.tasks.get(player.getEntityId()).size());
+
+        // Without single-instance this would grow to 2 (see the test above); with it,
+        // the previous task is cancelled and removed before the new one is added.
+        mechanic.execute(player, 1, List.of(player), true);
+        assertEquals(1, mechanic.tasks.get(player.getEntityId()).size());
+    }
+
+    @Test
+    void execute_singleInstance_firstInvocationBehavesNormally() {
+        RepeatMechanic mechanic = getMechanic(3, 0, 1, true);
+
+        boolean result = mechanic.execute(player, 1, List.of(player), true);
+
+        assertTrue(result);
+        assertEquals(1, mechanic.tasks.get(player.getEntityId()).size());
+    }
+
+    @Test
+    void execute_noTargets_returnsFalse() {
+        RepeatMechanic mechanic = getMechanic(3, 0, 1, false);
+
+        boolean result = mechanic.execute(player, 1, List.of(), true);
+
+        assertFalse(result);
+    }
+}

--- a/src/test/java/studio/magemonkey/fabled/dynamic/target/TargetComponentSelfTargetTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/target/TargetComponentSelfTargetTest.java
@@ -25,6 +25,11 @@ public class TargetComponentSelfTargetTest extends MockedTest {
         public List<LivingEntity> getTargets(LivingEntity caster, int level, List<LivingEntity> targets) {
             return targets;
         }
+
+        @Override
+        public String getKey() {
+            return "stub";
+        }
     }
 
     @BeforeEach

--- a/src/test/java/studio/magemonkey/fabled/dynamic/target/TargetComponentSelfTargetTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/target/TargetComponentSelfTargetTest.java
@@ -1,0 +1,80 @@
+package studio.magemonkey.fabled.dynamic.target;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import studio.magemonkey.codex.mccore.config.parse.DataSection;
+import studio.magemonkey.fabled.dynamic.DynamicSkill;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers TargetComponent#isValidTarget's self-targeting clause: previously self-targeting
+ * was excluded unconditionally, regardless of the "caster" (IncludeCaster) setting.
+ */
+public class TargetComponentSelfTargetTest extends MockedTest {
+    private Player caster;
+
+    private static class StubTargetComponent extends TargetComponent {
+        @Override
+        public List<LivingEntity> getTargets(LivingEntity caster, int level, List<LivingEntity> targets) {
+            return targets;
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        caster = genPlayer("Travja");
+    }
+
+    private TargetComponent getComponent(String includeCaster) {
+        TargetComponent component = new StubTargetComponent();
+        DynamicSkill    skill     = new DynamicSkill("Test");
+        DataSection     config    = new DataSection();
+        DataSection     data      = new DataSection();
+        // Use "both" so the ally/enemy grouping check never independently excludes the
+        // caster as their own target - isolates the self-targeting clause under test.
+        data.set("group", "both");
+        if (includeCaster != null) data.set("caster", includeCaster);
+        config.set("data", data);
+        component.load(skill, config);
+        return component;
+    }
+
+    @Test
+    void isValidTarget_includeCasterFalse_excludesSelf() {
+        TargetComponent component = getComponent("false");
+        assertFalse(component.isValidTarget(caster, caster, caster));
+    }
+
+    @Test
+    void isValidTarget_includeCasterTrue_allowsSelf() {
+        TargetComponent component = getComponent("true");
+        assertTrue(component.isValidTarget(caster, caster, caster));
+    }
+
+    @Test
+    void isValidTarget_includeCasterInArea_allowsSelf() {
+        TargetComponent component = getComponent("in area");
+        assertTrue(component.isValidTarget(caster, caster, caster));
+    }
+
+    @Test
+    void isValidTarget_default_stillExcludesSelf() {
+        // "caster" unset defaults to FALSE, preserving prior default behavior.
+        TargetComponent component = getComponent(null);
+        assertFalse(component.isValidTarget(caster, caster, caster));
+    }
+
+    @Test
+    void isValidTarget_includeCasterTrue_stillAllowsOtherTargets() {
+        Player other = genPlayer("Other");
+        TargetComponent component = getComponent("true");
+        assertTrue(component.isValidTarget(caster, caster, other));
+    }
+}


### PR DESCRIPTION
Split out of #1677 (piece 6 of 8 — see that PR for the full breakdown).

## What
Four small, unrelated fixes bundled together since each is a one-off, self-contained change too small to justify its own PR:

- **RepeatMechanic**: new `single-instance` setting cancels a caster's previous repeat tasks before starting a new one, instead of letting them stack.
- **TargetComponent**: allow self-targeting when `IncludeCaster` is anything other than `FALSE` (previously self-targeting was always excluded regardless of the `IncludeCaster` setting).
- **Skill#damage()**: wrap damage application in try-finally so the static `skillDamage` flag is always reset, even if dealing damage throws.
- **ComponentRegistry**: register `WorldTarget` — it already existed in the codebase but was never registered as a usable target component.

## Why split out separately
None of these depend on each other or on any other piece of #1677; grouped here purely to avoid four near-trivial PRs. Happy to split further if reviewers would prefer that.

## Testing
Could not build locally (private Maven repo unreachable in this sandbox). Needs manual/CI verification of each fix independently (repeat-mechanic stacking, self-targeting with IncludeCaster settings, WorldTarget now selectable in configs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCXEKdwwNjFkmjn46heQDM)_