### PR TITLE
feat: add PlayerMaxManaChangeEvent

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/api/event/PlayerMaxManaChangeEvent.java
+++ b/src/main/java/studio/magemonkey/fabled/api/event/PlayerMaxManaChangeEvent.java
@@ -1,0 +1,41 @@
+package studio.magemonkey.fabled.api.event;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import studio.magemonkey.fabled.api.player.PlayerData;
+
+/**
+ * Fired after Fabled finishes calculating a player's max mana (including class bonuses and attribute scaling).
+ * Listeners may call {@link #setMaxMana(double)} to apply additional flat bonuses.
+ */
+public class PlayerMaxManaChangeEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+    private final        PlayerData  playerData;
+    private              double      maxMana;
+
+    public PlayerMaxManaChangeEvent(PlayerData playerData, double maxMana) {
+        this.playerData = playerData;
+        this.maxMana = maxMana;
+    }
+
+    public PlayerData getPlayerData() {
+        return playerData;
+    }
+
+    public double getMaxMana() {
+        return maxMana;
+    }
+
+    public void setMaxMana(double maxMana) {
+        this.maxMana = Math.max(0, maxMana);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
+++ b/src/main/java/studio/magemonkey/fabled/api/player/PlayerData.java
@@ -2012,6 +2012,12 @@ public class PlayerData {
         this.maxHealth = this.scaleStat(AttributeManager.HEALTH, maxHealth);
         this.maxMana = this.scaleStat(AttributeManager.MANA, maxMana);
 
+        PlayerMaxManaChangeEvent maxManaEvent = new PlayerMaxManaChangeEvent(this, this.maxMana);
+        if (Bukkit.getPluginManager() != null) {
+            Bukkit.getPluginManager().callEvent(maxManaEvent);
+            this.maxMana = maxManaEvent.getMaxMana();
+        }
+
         this.mana = Math.min(mana, maxMana);
 
         // AsyncPlayerPreLoginEvent has to call this without player object to update Mana

--- a/src/test/java/studio/magemonkey/fabled/api/player/PlayerMaxManaChangeEventTest.java
+++ b/src/test/java/studio/magemonkey/fabled/api/player/PlayerMaxManaChangeEventTest.java
@@ -1,0 +1,80 @@
+package studio.magemonkey.fabled.api.player;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import studio.magemonkey.fabled.Fabled;
+import studio.magemonkey.fabled.api.classes.FabledClass;
+import studio.magemonkey.fabled.api.event.PlayerMaxManaChangeEvent;
+import studio.magemonkey.fabled.testutil.MockedTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PlayerMaxManaChangeEventTest extends MockedTest implements Listener {
+    private PlayerData playerData;
+    private double     bonus;
+    private Double     overrideValue;
+
+    @BeforeEach
+    public void setup() {
+        bonus = 0;
+        overrideValue = null;
+
+        PlayerMock player = genPlayer("Travja");
+        FabledClass fabledClass = new FabledClass("test", new ItemStack(Material.APPLE), 50) {
+        };
+        playerData = Fabled.getData(player);
+        playerData.setClass(null, fabledClass, true);
+
+        server.getPluginManager().registerEvent(PlayerMaxManaChangeEvent.class, this, EventPriority.NORMAL,
+                (listener, event) -> {
+                    PlayerMaxManaChangeEvent e = (PlayerMaxManaChangeEvent) event;
+                    if (overrideValue != null) {
+                        e.setMaxMana(overrideValue);
+                    } else if (bonus != 0) {
+                        e.setMaxMana(e.getMaxMana() + bonus);
+                    }
+                }, plugin, true);
+    }
+
+    @Test
+    void updatePlayerStat_firesMaxManaChangeEvent() {
+        playerData.updatePlayerStat(playerData.getPlayer());
+
+        assertEventFired(PlayerMaxManaChangeEvent.class);
+    }
+
+    @Test
+    void updatePlayerStat_noListenerChange_leavesBaseMaxManaIntact() {
+        playerData.updatePlayerStat(playerData.getPlayer());
+
+        double baseMana = playerData.getMaxMana();
+
+        // Re-running without a listener adjustment should be stable/idempotent.
+        playerData.updatePlayerStat(playerData.getPlayer());
+        assertEquals(baseMana, playerData.getMaxMana());
+    }
+
+    @Test
+    void updatePlayerStat_listenerBonus_isAppliedToMaxMana() {
+        playerData.updatePlayerStat(playerData.getPlayer());
+        double baseMana = playerData.getMaxMana();
+
+        bonus = 50;
+        playerData.updatePlayerStat(playerData.getPlayer());
+
+        assertEquals(baseMana + 50, playerData.getMaxMana());
+    }
+
+    @Test
+    void updatePlayerStat_negativeListenerOverride_clampsToZero() {
+        overrideValue = -100.0;
+        playerData.updatePlayerStat(playerData.getPlayer());
+
+        assertEquals(0, playerData.getMaxMana());
+    }
+}


### PR DESCRIPTION
Split out of #1677 (piece 7 of 8 — see that PR for the full breakdown).

## What
Fires a new `PlayerMaxManaChangeEvent` after Fabled computes a player's max mana (including class bonuses and attribute scaling), letting other plugins apply additional flat bonuses via `setMaxMana()` before it's applied. The result is clamped to a minimum of 0.

## Why split out separately
Small, additive, self-contained API surface — a new event class plus one call site. No dependency on any other piece of #1677.

## Testing
Could not build locally (private Maven repo unreachable in this sandbox). Needs manual/CI verification that max mana still computes correctly with no listeners attached, and that a listener calling `setMaxMana()` takes effect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCXEKdwwNjFkmjn46heQDM)_