### PR TITLE
feat: support multiple flag keys with All/Any match mode in Flag condition

### DIFF
--- a/src/main/java/studio/magemonkey/fabled/dynamic/condition/FlagCondition.java
+++ b/src/main/java/studio/magemonkey/fabled/dynamic/condition/FlagCondition.java
@@ -29,18 +29,30 @@ package studio.magemonkey.fabled.dynamic.condition;
 import org.bukkit.entity.LivingEntity;
 import studio.magemonkey.fabled.api.util.FlagManager;
 
+import java.util.List;
+
 /**
- * A condition for dynamic skills that requires the target to have a specified flag active
+ * A condition for dynamic skills that requires the target to have a specified flag (or set of flags) active
  */
 public class FlagCondition extends ConditionComponent {
-    private static final String TYPE = "type";
-    private static final String KEY  = "key";
+    private static final String TYPE  = "type";
+    private static final String MATCH = "match";
+    private static final String KEY   = "key";
 
     @Override
     boolean test(final LivingEntity caster, final int level, final LivingEntity target) {
-        final String  flag = filter(caster, target, settings.getString(KEY));
-        final boolean set  = !settings.getString(TYPE, "set").toLowerCase().equals("not set");
-        return FlagManager.hasFlag(target, flag) == set;
+        final List<String> keys = settings.getStringList(KEY);
+        final boolean      set  = !settings.getString(TYPE, "set").toLowerCase().equals("not set");
+
+        // No key configured behaves the same as the legacy single-key default of an unset flag
+        if (keys.isEmpty()) {
+            return !set;
+        }
+
+        final boolean matchAll = !settings.getString(MATCH, "all").equalsIgnoreCase("any");
+        return matchAll
+                ? keys.stream().allMatch(key -> FlagManager.hasFlag(target, filter(caster, target, key)) == set)
+                : keys.stream().anyMatch(key -> FlagManager.hasFlag(target, filter(caster, target, key)) == set);
     }
 
     @Override

--- a/src/test/java/studio/magemonkey/fabled/dynamic/condition/FlagConditionTest.java
+++ b/src/test/java/studio/magemonkey/fabled/dynamic/condition/FlagConditionTest.java
@@ -11,6 +11,8 @@ import studio.magemonkey.fabled.api.util.FlagManager;
 import studio.magemonkey.fabled.dynamic.DynamicSkill;
 import studio.magemonkey.fabled.testutil.MockedTest;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
@@ -48,6 +50,18 @@ public class FlagConditionTest extends MockedTest {
         return condition;
     }
 
+    private FlagCondition getCondition(List<String> keys, String type, String match) {
+        FlagCondition condition = new FlagCondition();
+        DataSection   config    = new DataSection();
+        DataSection   settings  = new DataSection();
+        settings.set("key", keys);
+        if (type != null) settings.set("type", type);
+        if (match != null) settings.set("match", match);
+        config.set("data", settings);
+        condition.load(null, config);
+        return condition;
+    }
+
     @Test
     void test_staticKey_matchesFlagOnTarget() {
         FlagManager.addFlag(target, "stunned", 100);
@@ -71,5 +85,69 @@ public class FlagConditionTest extends MockedTest {
 
         FlagManager.addFlag(target, "stunned", 100);
         assertFalse(condition.test(caster, 1, target));
+    }
+
+    @Test
+    void test_matchAll_set_requiresEveryKeySet() {
+        FlagCondition condition = getCondition(List.of("stunned", "silenced"), "set", "all");
+
+        FlagManager.addFlag(target, "stunned", 100);
+        assertFalse(condition.test(caster, 1, target));
+
+        FlagManager.addFlag(target, "silenced", 100);
+        assertTrue(condition.test(caster, 1, target));
+    }
+
+    @Test
+    void test_matchAny_set_requiresAtLeastOneKeySet() {
+        FlagCondition condition = getCondition(List.of("stunned", "silenced"), "set", "any");
+
+        assertFalse(condition.test(caster, 1, target));
+
+        FlagManager.addFlag(target, "silenced", 100);
+        assertTrue(condition.test(caster, 1, target));
+    }
+
+    @Test
+    void test_matchAll_notSet_requiresEveryKeyUnset() {
+        FlagCondition condition = getCondition(List.of("stunned", "silenced"), "not set", "all");
+
+        assertTrue(condition.test(caster, 1, target));
+
+        FlagManager.addFlag(target, "stunned", 100);
+        assertFalse(condition.test(caster, 1, target));
+    }
+
+    @Test
+    void test_matchAny_notSet_requiresAtLeastOneKeyUnset() {
+        FlagCondition condition = getCondition(List.of("stunned", "silenced"), "not set", "any");
+
+        FlagManager.addFlag(target, "stunned", 100);
+        assertTrue(condition.test(caster, 1, target)); // "silenced" is still unset
+
+        FlagManager.addFlag(target, "silenced", 100);
+        assertFalse(condition.test(caster, 1, target));
+    }
+
+    @Test
+    void test_missingMatch_defaultsToAll_backwardCompatible() {
+        FlagCondition condition = getCondition(List.of("stunned", "silenced"), "set", null);
+
+        FlagManager.addFlag(target, "stunned", 100);
+        assertFalse(condition.test(caster, 1, target));
+
+        FlagManager.addFlag(target, "silenced", 100);
+        assertTrue(condition.test(caster, 1, target));
+    }
+
+    @Test
+    void test_legacyScalarKey_stillTreatedAsSingleEntryList() {
+        // Older configs stored `key` as a plain string rather than a list;
+        // Settings#getStringList wraps scalars into a single-element list automatically.
+        FlagCondition condition = getCondition("stunned", "set");
+        assertFalse(condition.test(caster, 1, target));
+
+        FlagManager.addFlag(target, "stunned", 100);
+        assertTrue(condition.test(caster, 1, target));
     }
 }


### PR DESCRIPTION
## Summary
- Resolves #1796 by letting the `Flag` condition's `key` field hold multiple flags instead of just one.
- `FlagCondition` now reads `key` via `Settings#getStringList`, which already wraps a legacy scalar value into a single-entry list, so existing configs with `key: <name>` keep working unchanged.
- Adds a new `match` field (`All`/`Any`, defaults to `All`) that combines with the existing `type` (`Set`/`Not Set`) field to produce all four combinations requested in the issue: all set, all unset, any set, any unset.

## Test plan
- [x] Added unit tests in `FlagConditionTest` covering all-set/all-unset/any-set/any-unset match modes, the default-to-`All` backward-compat path, and the legacy scalar-key path.
- [ ] `mvn test` (couldn't run in this environment — the private Maven repo `repo.travja.dev` isn't reachable from the sandbox; please run CI/local build to confirm).

Companion editor-side change (multi-line Key list + Match dropdown) is in a separate PR against the `editor` branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_014F2gqH49hQXhuKqrLvCfmZ)_