### PR TITLE
feat: multi-key Key list + All/Any Match field for Flag condition

### DIFF
--- a/src/api/components/components.svelte.ts
+++ b/src/api/components/components.svelte.ts
@@ -1690,14 +1690,16 @@ class FlagCondition extends FabledCondition {
 	public constructor() {
 		super({
 			name:         'Flag',
-			description:  'Applies child components when the target is marked by the appropriate flag',
+			description:  'Applies child components when the target is marked by the appropriate flag(s)',
 			data:         [
 				new DropdownSelect('Type', 'type', ['Set', 'Not Set'], 'Set')
-					.setTooltip('Whether the flag should be set'),
-				new StringSelect('Key', 'key', 'key')
-					.setTooltip('The unique key representing the flag. This should match the key for when you set it using the Flag mechanic or the Flat Toggle mechanic')
+					.setTooltip('Whether the flag(s) should be set'),
+				new DropdownSelect('Match', 'match', ['All', 'Any'], 'All')
+					.setTooltip('Whether all of the keys must match, or just any one of them'),
+				new StringListSelect('Key', 'key', ['key'])
+					.setTooltip('The unique key(s) representing the flag(s). Add more lines to check multiple flags. This should match the key used when setting it via the Flag mechanic or the Flag Toggle mechanic')
 			],
-			summaryItems: ['type', 'key']
+			summaryItems: ['type', 'match', 'key']
 		});
 	}
 

--- a/src/api/options/stringlistselect.svelte.ts
+++ b/src/api/options/stringlistselect.svelte.ts
@@ -35,8 +35,8 @@ export default class StringListSelect extends Requirements implements ComponentO
 	getSummary = (): string => this.data?.value ? this.data.value.join(', ') : '';
 
 	deserialize = (yaml: Unknown) => {
-		const val = <string[]>yaml[this.key];
+		const val = <string[] | string>yaml[this.key];
 		if (val !== undefined)
-			this.data.value = val;
+			this.data.value = Array.isArray(val) ? val : [val];
 	};
 }


### PR DESCRIPTION
## Summary
- Companion editor-side change for #1796 / the backend PR that lets the `Flag` condition check multiple flags.
- `FlagCondition`'s `Key` field is now a `StringListSelect` (the existing multi-line list widget, same one used by `FlagTrigger`/`FlagExpireTrigger`) instead of a single `StringSelect`, and a new `Match` dropdown (`All`/`Any`) sits alongside the existing `Type` (`Set`/`Not Set`) dropdown.
- Fixed `StringListSelect#deserialize` to wrap a scalar YAML value into a single-entry list instead of assigning it directly — without this, every existing skill using the `Flag` condition (saved with a plain string `key:`) would load with a broken/mistyped list field once `Key` switched to a list type.

## Test plan
- [x] `npm run check` — same 13 pre-existing errors as the `editor` baseline, no new ones introduced.
- [x] `npx vitest run` — 23/23 passing.
- [ ] Manual check in the running editor: open a skill with a `Flag` condition, confirm `Key` renders as a multi-line list and `Match` appears as All/Any, and that a legacy skill with a scalar `key:` loads without data loss.

---
_Generated by [Claude Code](https://claude.ai/code/session_014F2gqH49hQXhuKqrLvCfmZ)_